### PR TITLE
fix: rotate client_id to force re-consent for OpenMeet scope (#49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Copy `server/.env.example` and fill in:
 ```
 PORT=3000
 CLIENT_URL=http://localhost:5173
-ATPROTO_CLIENT_ID=https://avails.zhgnv.com/client-metadata.json
+ATPROTO_CLIENT_ID=https://avails.zhgnv.com/api/auth/client-metadata-v2.json
 ATPROTO_REDIRECT_URI=https://avails.zhgnv.com/api/auth/callback
 SESSION_SECRET=<random string>
 RESEND_API_KEY=<from resend.com>

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,6 +1,6 @@
 PORT=3000
 CLIENT_URL=http://localhost:5173
-ATPROTO_CLIENT_ID=https://avails.zhgnv.com/client-metadata.json
+ATPROTO_CLIENT_ID=https://avails.zhgnv.com/api/auth/client-metadata-v2.json
 ATPROTO_REDIRECT_URI=https://avails.zhgnv.com/api/auth/callback
 SESSION_SECRET=change-me-to-random-string
 RESEND_API_KEY=re_xxxxxxxxxxxx

--- a/server/src/mcp/tools.js
+++ b/server/src/mcp/tools.js
@@ -660,10 +660,14 @@ async function publishToOpenmeet({ did, rkey }, authContext) {
   }
 
   // Get OpenMeet token via ATProto service auth
-  const token = await getOpenMeetToken(auth.oauthSession);
-  if (!token) {
+  const tokenResult = await getOpenMeetToken(auth.oauthSession);
+  if (tokenResult.error === 'scope-missing') {
+    throw new Error('Your Bluesky session is missing the OpenMeet permission. Sign out and sign back in via the Avails web UI to grant it.');
+  }
+  if (!tokenResult.token) {
     throw new Error('Could not authenticate with OpenMeet. Do you have an OpenMeet account linked to your Bluesky?');
   }
+  const token = tokenResult.token;
 
   const url = pollUrl(did, rkey);
   const OPENMEET_API = process.env.OPENMEET_API_URL || 'https://api.openmeet.net';

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -102,8 +102,12 @@ export async function getClient() {
   return _client;
 }
 
-// Expose client metadata at the URL declared as client_id
-router.get('/client-metadata.json', async (req, res, next) => {
+// Expose client metadata at the URL declared as client_id.
+// Path is versioned so we can rotate the client_id when scopes change — ATProto
+// OAuth has no prompt=consent; bsky caches grants per client_id and auto-approves
+// existing users without re-prompting for new scopes (see #49). Bumping the path
+// forces every user through a fresh consent flow with the current scope set.
+router.get('/client-metadata-v2.json', async (req, res, next) => {
   try {
     const client = await getClient();
     res.json(client.clientMetadata);

--- a/server/src/routes/openmeet.js
+++ b/server/src/routes/openmeet.js
@@ -15,10 +15,17 @@ router.post('/publish', requireAuth, async (req, res, next) => {
     }
 
     // Get OpenMeet auth token via ATProto service auth
-    const token = await getOpenMeetToken(req.oauthSession);
-    if (!token) {
+    const tokenResult = await getOpenMeetToken(req.oauthSession);
+    if (tokenResult.error === 'scope-missing') {
+      return res.status(403).json({
+        error: 'needs-reauth',
+        message: 'Your Bluesky session is missing the OpenMeet permission. Sign out and sign back in to grant it.',
+      });
+    }
+    if (!tokenResult.token) {
       return res.status(502).json({ error: 'Could not authenticate with OpenMeet. Do you have an OpenMeet account linked to your Bluesky?' });
     }
+    const token = tokenResult.token;
 
     const eventPayload = {
       name: title,
@@ -81,6 +88,10 @@ const OPENMEET_DID = 'did:web:api.openmeet.net';
  * Get an OpenMeet bearer token via ATProto service auth.
  * 1. Call user's PDS to get a service auth JWT (signed by their identity)
  * 2. Exchange that JWT for OpenMeet access tokens
+ *
+ * Returns { token } on success, { error: 'scope-missing' } when the PDS
+ * rejects for lack of the OpenMeet RPC scope (grant needs re-consent),
+ * or { token: null } for any other failure.
  */
 export async function getOpenMeetToken(oauthSession) {
   // Step 1: Get a service auth JWT from the user's PDS
@@ -96,11 +107,14 @@ export async function getOpenMeetToken(oauthSession) {
   if (!serviceAuthRes.ok) {
     const text = await serviceAuthRes.text();
     console.log('[openmeet] PDS getServiceAuth failed:', serviceAuthRes.status, text);
-    return null;
+    if (serviceAuthRes.status === 403 && text.includes('ScopeMissingError')) {
+      return { error: 'scope-missing', token: null };
+    }
+    return { token: null };
   }
 
   const { token: pdsJwt } = await serviceAuthRes.json();
-  if (!pdsJwt) return null;
+  if (!pdsJwt) return { token: null };
 
   // Step 2: Exchange PDS JWT for OpenMeet tokens
   const exchangeRes = await fetch(`${OPENMEET_API}/api/v1/auth/atproto/service-auth`, {
@@ -115,11 +129,11 @@ export async function getOpenMeetToken(oauthSession) {
   if (!exchangeRes.ok) {
     const text = await exchangeRes.text();
     console.log('[openmeet] Token exchange failed:', exchangeRes.status, text);
-    return null;
+    return { token: null };
   }
 
   const authData = await exchangeRes.json();
-  return authData.token || authData.accessToken || null;
+  return { token: authData.token || authData.accessToken || null };
 }
 
 // POST /api/openmeet/availability — get calendar events from OpenMeet for authenticated user
@@ -132,10 +146,14 @@ router.post('/availability', requireAuth, async (req, res, next) => {
     }
 
     // Get OpenMeet token via ATProto service auth
-    const token = await getOpenMeetToken(req.oauthSession);
-    if (!token) {
+    const tokenResult = await getOpenMeetToken(req.oauthSession);
+    if (tokenResult.error === 'scope-missing') {
+      return res.json({ available: false, reason: 'needs-reauth', events: [] });
+    }
+    if (!tokenResult.token) {
       return res.json({ available: false, reason: 'no-openmeet-account', events: [] });
     }
+    const token = tokenResult.token;
 
     // Fetch calendar events from OpenMeet
     const eventsRes = await fetch(`${OPENMEET_API}/api/external-calendar/events`, {


### PR DESCRIPTION
## Summary
- bsky caches OAuth grants per `client_id` with no `prompt=consent`, so users who authorized Avails before the OpenMeet RPC scope was added auto-approve sign-ins without ever being prompted for the new scope — every OpenMeet call then fails with `ScopeMissingError`. Rotating the client-metadata URL (`/client-metadata.json` → `/api/auth/client-metadata-v2.json`) makes bsky treat Avails as a new app, which forces a fresh consent screen with the current scope set.
- Splits `getOpenMeetToken` return value so `publish`, `availability`, and the MCP `publish_to_openmeet` tool can distinguish "scope-missing grant, needs re-consent" from "no linked OpenMeet account" and surface a clear "sign out and sign back in" message instead of the misleading "linked account?" prompt.

Closes #49.

## Verified
- [x] Reproduced the bug against production — three `[openmeet] PDS getServiceAuth failed: 403 {"error":"ScopeMissingError","message":"Missing required scope \"rpc:net.openmeet.auth?aud=did:web:api.openmeet.net\""}` entries in Railway logs when clicking "Publish to OpenMeet" on a scheduled poll.
- [x] `node --check` on the three modified server files
- [x] `npm test` — all 33 tests pass (23 validation + 10 integration)

## Deploy steps
1. Merge this PR.
2. Set `ATPROTO_CLIENT_ID=https://avails.zhgnv.com/api/auth/client-metadata-v2.json` in Railway.
3. Redeploy. Existing sessions will fail restore against the new `client_id` and be evicted; users will see a fresh consent screen on next sign-in that includes the OpenMeet scope.
4. Test: sign in, confirm consent screen lists "access OpenMeet" (or the `rpc:net.openmeet.auth` line); schedule a test poll and verify publish-to-OpenMeet succeeds.

## Test plan
- [ ] Sign in at https://avails.zhgnv.com after deploy — consent screen shows the OpenMeet scope
- [ ] Finalize a test poll and click "Publish to OpenMeet" — event created on OpenMeet
- [ ] Calendar availability overlay on the grid pulls events from OpenMeet

🤖 Generated with [Claude Code](https://claude.com/claude-code)