### PR TITLE
fix: use wildcard aud in OpenMeet rpc scope + rotate client_id to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Copy `server/.env.example` and fill in:
 ```
 PORT=3000
 CLIENT_URL=http://localhost:5173
-ATPROTO_CLIENT_ID=https://avails.zhgnv.com/api/auth/client-metadata-v2.json
+ATPROTO_CLIENT_ID=https://avails.zhgnv.com/api/auth/client-metadata-v3.json
 ATPROTO_REDIRECT_URI=https://avails.zhgnv.com/api/auth/callback
 SESSION_SECRET=<random string>
 RESEND_API_KEY=<from resend.com>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,8 +61,8 @@ There is no database. ATProto PDS is the data store:
 Both use ATProto service auth flow:
    - Call `com.atproto.server.getServiceAuth` on user's PDS with `aud: did:web:api.openmeet.net`, `lxm: net.openmeet.auth`
    - PDS signs a JWT → exchange at OpenMeet's `POST /api/v1/auth/atproto/service-auth`
-   - Requires `rpc:net.openmeet.auth?aud=did:web:api.openmeet.net` in OAuth scopes
-   - **Blocked by #49** — ATProto OAuth doesn't re-prompt for upgraded scopes on existing grants. Users who authorized before the scope was added can't use OpenMeet features until re-consent is forced.
+   - Requires `rpc:net.openmeet.auth?aud=*` in OAuth scopes. The pinned DID form (`aud=did:web:api.openmeet.net`) was silently dropped from the consent grant by bsky; the wildcard form is what OpenMeet's own documentation recommends.
+   - **#49 gotcha** — ATProto OAuth doesn't re-prompt for upgraded scopes on existing grants. Rotate the `client_id` (client-metadata URL version bump) to force re-consent for every user with the current scope set.
 
 3. **Groups** (#50): OpenMeet has ATProto-native group management ("Groups you organize" / "Groups you're part of"). Could serve as shared community layer for poll scoping — explore once scope issue is resolved.
 
@@ -111,7 +111,7 @@ Embedded `POST /mcp` JSON-RPC endpoint with ATProto OAuth (Smoke Signal pattern)
 
 ### OAuth
 
-Standard OAuth 2.0 discovery (RFC 9728 + 8414) with PKCE S256 — Claude Code handles auth automatically. Granular ATProto scopes: `repo:chat.avails.scheduling.poll`, `repo:chat.avails.scheduling.response`, `rpc:net.openmeet.auth`.
+Standard OAuth 2.0 discovery (RFC 9728 + 8414) with PKCE S256 — Claude Code handles auth automatically. Granular ATProto scopes: `repo:chat.avails.scheduling.poll`, `repo:chat.avails.scheduling.response`, `rpc:net.openmeet.auth?aud=*`.
 
 MCP OAuth flow piggybacks on the web UI's ATProto OAuth — `/api/auth/callback` detects MCP flows via `tryMcpCallback()` (exported from `mcp/oauth.js`) and redirects to the MCP client instead of the homepage.
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,6 +1,6 @@
 PORT=3000
 CLIENT_URL=http://localhost:5173
-ATPROTO_CLIENT_ID=https://avails.zhgnv.com/api/auth/client-metadata-v2.json
+ATPROTO_CLIENT_ID=https://avails.zhgnv.com/api/auth/client-metadata-v3.json
 ATPROTO_REDIRECT_URI=https://avails.zhgnv.com/api/auth/callback
 SESSION_SECRET=change-me-to-random-string
 RESEND_API_KEY=re_xxxxxxxxxxxx

--- a/server/src/mcp/oauth.js
+++ b/server/src/mcp/oauth.js
@@ -47,7 +47,7 @@ router.get('/.well-known/oauth-authorization-server', (req, res) => {
     grant_types_supported: ['authorization_code', 'refresh_token'],
     token_endpoint_auth_methods_supported: ['none'],
     code_challenge_methods_supported: ['S256'],
-    scopes_supported: ['atproto', 'repo:chat.avails.scheduling.poll', 'repo:chat.avails.scheduling.response', 'rpc:net.openmeet.auth?aud=did:web:api.openmeet.net'],
+    scopes_supported: ['atproto', 'repo:chat.avails.scheduling.poll', 'repo:chat.avails.scheduling.response', 'rpc:net.openmeet.auth?aud=*'],
   });
 });
 

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -78,7 +78,7 @@ export async function getClient() {
       token_endpoint_auth_method: 'private_key_jwt',
       token_endpoint_auth_signing_alg: 'ES256',
       dpop_bound_access_tokens: true,
-      scope: 'atproto repo:chat.avails.scheduling.poll repo:chat.avails.scheduling.response rpc:net.openmeet.auth?aud=did:web:api.openmeet.net',
+      scope: 'atproto repo:chat.avails.scheduling.poll repo:chat.avails.scheduling.response rpc:net.openmeet.auth?aud=*',
       jwks_uri: `${clientUri}/api/auth/jwks.json`,
     },
 
@@ -107,7 +107,7 @@ export async function getClient() {
 // OAuth has no prompt=consent; bsky caches grants per client_id and auto-approves
 // existing users without re-prompting for new scopes (see #49). Bumping the path
 // forces every user through a fresh consent flow with the current scope set.
-router.get('/client-metadata-v2.json', async (req, res, next) => {
+router.get('/client-metadata-v3.json', async (req, res, next) => {
   try {
     const client = await getClient();
     res.json(client.clientMetadata);
@@ -139,7 +139,7 @@ router.get('/login', async (req, res, next) => {
 
     const url = await client.authorize(handle, {
       signal: ac.signal,
-      scope: 'atproto repo:chat.avails.scheduling.poll repo:chat.avails.scheduling.response rpc:net.openmeet.auth?aud=did:web:api.openmeet.net',
+      scope: 'atproto repo:chat.avails.scheduling.poll repo:chat.avails.scheduling.response rpc:net.openmeet.auth?aud=*',
     });
 
     res.redirect(url.toString());


### PR DESCRIPTION
## Summary
- After #73 forced fresh consent via v2 client_id rotation, bsky still silently dropped `rpc:net.openmeet.auth?aud=did:web:api.openmeet.net` from the grant — the consent screen never displayed it and the PDS kept rejecting `getServiceAuth` with `ScopeMissingError`. Switching the `aud` to a wildcard matches the form [OpenMeet's own documentation recommends](https://openmeet.net/cross-app-authentication-atproto) for third-party apps.
- Another client_id rotation (v2 → v3) is required because bsky caches grants per `client_id` and won't re-prompt users on scope changes under the same `client_id`.

Follow-up to #73 / #49.

## Verified
- [x] `node --check` on modified files
- [x] `npm test` — 33/33 pass
- [x] Previous attempt reproduced end-to-end: after v2 rotation + fresh sign-in, publish-to-OpenMeet returned the new `needs-reauth` error and Railway logs show the expected `[openmeet] PDS getServiceAuth failed: 403 {"error":"ScopeMissingError","message":"Missing required scope \"rpc:net.openmeet.auth?aud=did:web:api.openmeet.net\""}`. Wildcard form not yet tested live.

## Deploy steps
1. Merge.
2. Set `ATPROTO_CLIENT_ID=https://avails.zhgnv.com/api/auth/client-metadata-v3.json` in Railway.
3. Redeploy.
4. Sign out + sign in; confirm consent screen lists the rpc scope (or that publish-to-OpenMeet succeeds end-to-end regardless of UI display).

## Test plan
- [ ] Sign in against v3 — consent screen appears fresh
- [ ] Publish a finalized poll to OpenMeet — event created successfully
- [ ] Calendar availability overlay pulls events

🤖 Generated with [Claude Code](https://claude.com/claude-code)