### PR TITLE
fix(theme): warm the shadcn token layer (#84)

### DIFF
--- a/client/src/components/SchedulingGrid.jsx
+++ b/client/src/components/SchedulingGrid.jsx
@@ -47,11 +47,12 @@ function computeHeatmap(responses, dates, times) {
   return map
 }
 
+// Match AvailGrid's heatmap exactly so the green doesn't shift when the creator
+// switches from response view to scheduling view (Consensus Green, alpha 0.2 → 0.9).
 function slotColor(count, total) {
   if (!count || !total) return null
-  const ratio = count / total
-  const lightness = 85 - ratio * 45
-  return `hsl(142, 60%, ${lightness}%)`
+  const alpha = 0.2 + 0.7 * (count / total)
+  return `rgba(34, 197, 94, ${alpha})`
 }
 
 export default function SchedulingGrid({

--- a/client/src/components/ui/dialog.jsx
+++ b/client/src/components/ui/dialog.jsx
@@ -37,7 +37,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        "fixed inset-0 isolate z-50 bg-[#1c1a17]/15 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
         className
       )}
       {...props} />

--- a/client/src/pages/About.jsx
+++ b/client/src/pages/About.jsx
@@ -80,8 +80,9 @@ export default function About() {
             </div>
           </div>
 
-          {/* Pull quote */}
-          <div className="mt-12 border-l-4 border-[#0d9488] pl-8 py-2">
+          {/* Pull quote — top accent rule, not a side-stripe (DESIGN.md ban) */}
+          <div className="mt-12 py-2">
+            <div className="w-10 h-1 rounded-full bg-[#0d9488] mb-5" />
             <p className="text-2xl font-semibold text-[#1a1a1a] leading-snug tracking-tight">
               Data portability is not a feature.
               <br />

--- a/client/src/styles/globals.css
+++ b/client/src/styles/globals.css
@@ -45,24 +45,29 @@
 }
 
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
+  /* Warm neutral scale — hue ~80 (paper), low chroma. Mirrors the bespoke hex
+     palette (Paper Cream #faf9f6, Oat #f5f3ef, Hairline #e8e5df, Warm Ink #1a1a1a,
+     Stone #6b6560) so shadcn surfaces inherit warmth instead of cold grey.
+     See DESIGN.md "The No Cold Grey Rule". */
+  --background: oklch(0.985 0.004 85);
+  --foreground: oklch(0.205 0.005 60);
+  --card: oklch(0.985 0.004 85);
+  --card-foreground: oklch(0.205 0.005 60);
+  --popover: oklch(0.99 0.004 85);
+  --popover-foreground: oklch(0.205 0.005 60);
+  --primary: oklch(0.205 0.005 60);
+  --primary-foreground: oklch(0.985 0.004 85);
+  --secondary: oklch(0.962 0.005 80);
+  --secondary-foreground: oklch(0.205 0.005 60);
+  --muted: oklch(0.962 0.005 80);
+  --muted-foreground: oklch(0.52 0.008 70);
+  --accent: oklch(0.95 0.006 80);
+  --accent-foreground: oklch(0.205 0.005 60);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --border: oklch(0.915 0.006 78);
+  --input: oklch(0.915 0.006 78);
+  /* Focus ring = Gather Teal (brand accent), aids the keyboard-a11y work in #86 */
+  --ring: oklch(0.62 0.1 185);
   --radius: 0.625rem;
 }
 


### PR DESCRIPTION
## What

`/impeccable colorize` — the "warmth foundation" pass from the design critique. Makes the warm "village notice board" palette real at the token layer instead of a facade applied as inline spot-corrections.

## Changes

- **`globals.css` (the P0, #84):** the shadcn `:root` tokens were all chroma-0 **cold** OKLCH (`--background: oklch(1 0 0)` = pure white, not Paper Cream). Every inheriting surface (Dialog, Popover, Tooltip, Select, and `SchedulingGrid`'s `bg-muted/30` empty cells) rendered cold while component files hardcoded warm hex. Rewarmed the whole neutral scale toward hue ~80 low-chroma to mirror the bespoke palette (`#faf9f6` / `#f5f3ef` / `#e8e5df` / `#1a1a1a` / `#6b6560`). Set `--ring` to Gather Teal for on-brand, a11y-friendly focus.
- **`dialog.jsx`:** warm overlay scrim (`bg-black/10` → `bg-[#1c1a17]/15`). Resolves the detector's pure-black finding.
- **`About.jsx`:** replaced the `border-l-4` side-stripe pull-quote (banned by DESIGN.md) with a top accent rule — a full element, not a side stripe.
- **`SchedulingGrid.jsx`:** unified the heatmap green with `AvailGrid` (both now `rgba(34,197,94, alpha)`) so consensus color doesn't shift when the creator switches to scheduling view.

## Verification

- `npm run build` passes.
- ⚠️ **Not eyeballed on a live render** — token/scrim changes are visual and should get a quick look once deployed. The warmth shift is subtle by design.

## Scope note

This is the first of the critique's prioritized fixes. Remaining tracked: #85 (colorblind heatmap), #86 (keyboard grid), #87 (hero copy), #88 (PollCreator disclosure), #51 (confirm dialogs).

Closes #84
