### PR TITLE
feat(a11y): keyboard + screen-reader operable availability grids (#86)

### DIFF
--- a/client/src/components/AvailGrid.jsx
+++ b/client/src/components/AvailGrid.jsx
@@ -100,6 +100,7 @@ export default function AvailGrid({
   const [dragState, setDragState] = useState(null) // null | { pending: Set<string>, removing: boolean }
   const [activeSlot, setActiveSlot] = useState(null) // slot key tapped in read-only mode
   const activeSlotRef = useRef(null) // ref mirror to avoid stale closure in commitDrag
+  const [focusCell, setFocusCell] = useState({ row: 0, col: 0 }) // roving tabindex for keyboard nav
 
   // Clear activeSlot when entering edit mode
   useEffect(() => {
@@ -182,6 +183,7 @@ export default function AvailGrid({
 
   const handlePointerDown = useCallback(
     (e, row, col) => {
+      setFocusCell({ row, col }) // keep keyboard focus in sync with pointer
       const key = `${visibleDates[col]}T${times[row]}`
       if (readOnly) {
         e.preventDefault()
@@ -282,6 +284,49 @@ export default function AvailGrid({
     return `${count}/${totalRespondents} available — ${names.join(', ')}`
   }
 
+  // Keyboard navigation (WCAG 2.1.1) — roving tabindex over cells with arrow
+  // keys to move and Space/Enter to toggle. Clamp focus to current page bounds.
+  const fRow = Math.min(focusCell.row, Math.max(0, times.length - 1))
+  const fCol = Math.min(focusCell.col, Math.max(0, visibleDates.length - 1))
+
+  function focusCellAt(row, col) {
+    containerRef.current
+      ?.querySelector(`[data-row="${row}"][data-col="${col}"]`)
+      ?.focus()
+  }
+
+  function handleGridKeyDown(e) {
+    const maxRow = times.length - 1
+    const maxCol = visibleDates.length - 1
+    let r = fRow
+    let c = fCol
+    if (e.key === 'ArrowUp') r = Math.max(0, fRow - 1)
+    else if (e.key === 'ArrowDown') r = Math.min(maxRow, fRow + 1)
+    else if (e.key === 'ArrowLeft') c = Math.max(0, fCol - 1)
+    else if (e.key === 'ArrowRight') c = Math.min(maxCol, fCol + 1)
+    else if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      const key = `${visibleDates[fCol]}T${times[fRow]}`
+      if (readOnly) {
+        const newActive = activeSlotRef.current === key ? null : key
+        activeSlotRef.current = newActive
+        setActiveSlot(newActive)
+        onHoverSlot?.(newActive)
+      } else {
+        const next = new Set(mySlots)
+        if (next.has(key)) next.delete(key)
+        else next.add(key)
+        onSlotsChange?.(next)
+      }
+      return
+    } else {
+      return
+    }
+    e.preventDefault()
+    setFocusCell({ row: r, col: c })
+    requestAnimationFrame(() => focusCellAt(r, c))
+  }
+
   return (
     <TooltipProvider delayDuration={300}>
       <div className="space-y-2">
@@ -315,6 +360,9 @@ export default function AvailGrid({
           onPointerLeave={() => { if (!downCell.current && !activeSlotRef.current) onHoverSlot?.(null) }}
         >
           <div
+            role="group"
+            aria-label="Availability grid. Use arrow keys to move between time slots and Space to toggle your availability."
+            onKeyDown={handleGridKeyDown}
             className="grid w-full rounded-lg border border-[#d8d4cf] overflow-hidden"
             style={{
               gridTemplateColumns: `clamp(3rem, 12vw, 5rem) repeat(${visibleDates.length}, 1fr)`,
@@ -376,11 +424,23 @@ export default function AvailGrid({
                 const prevEventName = prevKey ? slotEvents[prevKey] : null
                 const showEventName = eventName && eventName !== prevEventName
 
+                const fd = formatDate(date)
+                const cellLabel =
+                  `${fd.dayName} ${fd.monthDay} at ${time}` +
+                  (totalRespondents > 0 ? `, ${heatCount} of ${totalRespondents} available` : ', no responses yet') +
+                  (isBusy ? ', busy on your calendar' : '') +
+                  (isScheduled ? ', scheduled time' : '') +
+                  (!readOnly ? (isMine ? ', selected' : ', not selected') : '')
+
                 const cell = (
                   <div
                     key={key}
                     data-row={rowIdx}
                     data-col={colIdx}
+                    role="button"
+                    aria-label={cellLabel}
+                    aria-pressed={readOnly ? undefined : isMine}
+                    tabIndex={rowIdx === fRow && colIdx === fCol ? 0 : -1}
                     className={cn(
                       'avail-cell h-8 cursor-pointer',
                       time.endsWith(':00') && rowIdx > 0 && slotMinutes < 60 && 'avail-cell--hour',

--- a/client/src/components/SchedulingGrid.jsx
+++ b/client/src/components/SchedulingGrid.jsx
@@ -88,6 +88,9 @@ export default function SchedulingGrid({
   const curCell = useRef(null)
   const [dragPending, setDragPending] = useState(null) // Set<string> | null
   const [selectedSlots, setSelectedSlots] = useState(new Set())
+  const [focusCell, setFocusCell] = useState({ row: 0, col: 0 }) // roving tabindex
+  const kbAnchor = useRef(null) // keyboard block-selection anchor
+  const gridRef = useRef(null)
 
   // Date pagination — mirror AvailGrid: show max 7 dates at a time with arrows.
   // Without this the grid renders every day in one row and overflows the viewport
@@ -119,6 +122,7 @@ export default function SchedulingGrid({
 
   const handlePointerDown = useCallback((e, row, col) => {
     e.preventDefault()
+    setFocusCell({ row, col }) // keep keyboard focus in sync with pointer
     downCell.current = { row, col }
     curCell.current = { row, col }
     const key = `${visibleDates[col]}T${times[row]}`
@@ -148,6 +152,54 @@ export default function SchedulingGrid({
     document.addEventListener('pointerup', commitDrag)
     return () => document.removeEventListener('pointerup', commitDrag)
   }, [commitDrag])
+
+  // Keyboard navigation (WCAG 2.1.1). Arrows move; Space/Enter anchors a single
+  // cell; Shift+Up/Down extends the time block within the anchor's column.
+  const fRow = Math.min(focusCell.row, Math.max(0, times.length - 1))
+  const fCol = Math.min(focusCell.col, Math.max(0, visibleDates.length - 1))
+
+  function focusCellAt(row, col) {
+    gridRef.current
+      ?.querySelector(`[data-row="${row}"][data-col="${col}"]`)
+      ?.focus()
+  }
+
+  function handleGridKeyDown(e) {
+    const maxRow = times.length - 1
+    const maxCol = visibleDates.length - 1
+    let r = fRow
+    let c = fCol
+    if (e.key === 'ArrowUp') r = Math.max(0, fRow - 1)
+    else if (e.key === 'ArrowDown') r = Math.min(maxRow, fRow + 1)
+    else if (e.key === 'ArrowLeft') c = Math.max(0, fCol - 1)
+    else if (e.key === 'ArrowRight') c = Math.min(maxCol, fCol + 1)
+    else if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      const key = `${visibleDates[fCol]}T${times[fRow]}`
+      kbAnchor.current = { row: fRow, col: fCol }
+      setSelectedSlots(new Set([key]))
+      onSelect([key])
+      return
+    } else {
+      return
+    }
+    e.preventDefault()
+    // Shift + vertical extends the contiguous block from the anchor (same column)
+    if (e.shiftKey && (e.key === 'ArrowUp' || e.key === 'ArrowDown')) {
+      if (!kbAnchor.current || kbAnchor.current.col !== fCol) {
+        kbAnchor.current = { row: fRow, col: fCol }
+      }
+      const col = kbAnchor.current.col
+      const lo = Math.min(kbAnchor.current.row, r)
+      const hi = Math.max(kbAnchor.current.row, r)
+      const sel = new Set()
+      for (let i = lo; i <= hi; i++) sel.add(`${visibleDates[col]}T${times[i]}`)
+      setSelectedSlots(sel)
+      onSelect(Array.from(sel).sort())
+    }
+    setFocusCell({ row: r, col: c })
+    requestAnimationFrame(() => focusCellAt(r, c))
+  }
 
   return (
     <div className="space-y-4">
@@ -230,6 +282,10 @@ export default function SchedulingGrid({
         style={{ touchAction: 'none', cursor: 'crosshair' }}
       >
         <div
+          ref={gridRef}
+          role="group"
+          aria-label="Time-block picker. Use arrow keys to move, Space to start a block, Shift with up or down to extend it."
+          onKeyDown={handleGridKeyDown}
           className="grid w-full"
           style={{
             gridTemplateColumns: `clamp(3rem, 12vw, 5rem) repeat(${visibleDates.length}, 1fr)`,
@@ -259,10 +315,21 @@ export default function SchedulingGrid({
                 const bgColor = heatCount > 0 ? slotColor(heatCount, totalRespondents) : undefined
                 const isPending = dragPending && dragPending.has(key)
                 const isSelected = selectedSlots.has(key)
+                const fd = formatDate(date)
+                const cellLabel =
+                  `${fd.dayName} ${fd.monthDay} at ${time}` +
+                  (heatCount > 0 ? `, ${heatCount} of ${totalRespondents} available` : '') +
+                  (isSelected ? ', selected for the meeting' : '')
 
                 return (
                   <div
                     key={key}
+                    data-row={rowIdx}
+                    data-col={colIdx}
+                    role="button"
+                    aria-label={cellLabel}
+                    aria-pressed={isSelected}
+                    tabIndex={rowIdx === fRow && colIdx === fCol ? 0 : -1}
                     className={cn(
                       'avail-cell h-8',
                       rowIdx === 0 && 'rounded-t',

--- a/client/src/styles/avail-grid.css
+++ b/client/src/styles/avail-grid.css
@@ -192,3 +192,17 @@
 .avail-cell--active::after {
   z-index: -1;
 }
+
+/* Keyboard focus ring (WCAG 2.4.7) — visible when navigating cells by keyboard */
+.avail-cell:focus-visible {
+  outline: 2px solid #0d9488;
+  outline-offset: -2px;
+  z-index: 4;
+}
+
+/* Respect reduced-motion: drop the coaching pulse + scheduled shimmer */
+@media (prefers-reduced-motion: reduce) {
+  .avail-cell { transition: none; }
+  .avail-cell--empty:first-of-type { animation: none; }
+  .avail-scheduled-card::after { animation: none; }
+}


### PR DESCRIPTION
## What

`/impeccable harden` — #86. The availability grid is the core action of the product and was **pointer-only**: a keyboard or screen-reader user arriving at a poll link could not mark a single slot. That's a WCAG 2.1.1 failure on the stated AA target, on the one component that matters most.

## Changes

**AvailGrid (responder):**
- `role="group"` + descriptive `aria-label`; cells become `role="button"` with `aria-pressed` (selection state) and a full `aria-label` that also announces the **consensus count** ("Mon Jun 3 at 9:00, 3 of 5 available, selected") — a screen-reader-side redundancy for the color heatmap (partial assist to #85).
- Roving `tabIndex` + arrow-key navigation; Space/Enter toggles the focused cell (and the tap-highlight in read-only results mode). Pointer taps sync the focus position.

**SchedulingGrid (creator):** same roles/labels/roving tabindex; Space anchors a block, Shift+Up/Down extends it within a column — keyboard parity with the drag gesture.

**Both:** visible `:focus-visible` ring on cells (WCAG 2.4.7) and a `prefers-reduced-motion` guard for the coaching pulse + scheduled shimmer.

## Verification

- `npm run build` passes.
- ⚠️ **Not yet driven with a real keyboard / screen reader** — the authed app can't render headlessly here. Worth a Tab-into-grid + arrow + Space pass (and a quick VoiceOver/NVDA listen) before/after merge. An `axe` run on a poll page would also confirm.

## Scope note

Remaining critique queue: #85 (in-cell visual count for colorblind — this PR adds the SR/aria side; the visual cue is still open), #87 (hero copy), #88 (PollCreator), #51 (confirm dialogs), then `/impeccable polish`.

Closes #86
