### PR TITLE
feat(a11y): show respondent count in heatmap cells (#85)

### DIFF
--- a/client/src/components/AvailGrid.jsx
+++ b/client/src/components/AvailGrid.jsx
@@ -470,6 +470,13 @@ export default function AvailGrid({
                     onPointerDown={(e) => handlePointerDown(e, rowIdx, colIdx)}
                     onPointerEnter={(e) => handlePointerEnter(e, rowIdx, colIdx)}
                   >
+                    {/* Redundant non-color cue (WCAG 1.4.1): show the respondent
+                        count so consensus is legible without relying on green. */}
+                    {heatCount > 0 && !focusedName && (
+                      <span className="pointer-events-none absolute inset-0 flex items-center justify-center text-[10px] font-medium leading-none text-[#1a1a1a]/55 tabular-nums">
+                        {heatCount}
+                      </span>
+                    )}
                     {showEventName && (
                       <span className="absolute left-1 right-1 top-0.5 bottom-0.5 flex items-start rounded bg-rose-400/90 px-1.5 py-0.5 text-[11px] leading-tight text-white font-medium truncate pointer-events-none z-[1] shadow-sm">
                         {eventName}

--- a/client/src/components/SchedulingGrid.jsx
+++ b/client/src/components/SchedulingGrid.jsx
@@ -343,7 +343,14 @@ export default function SchedulingGrid({
                     }}
                     onPointerDown={(e) => handlePointerDown(e, rowIdx, colIdx)}
                     onPointerEnter={(e) => handlePointerEnter(e, rowIdx, colIdx)}
-                  />
+                  >
+                    {/* Redundant non-color cue (WCAG 1.4.1) — respondent count */}
+                    {heatCount > 0 && (
+                      <span className="pointer-events-none absolute inset-0 flex items-center justify-center text-[10px] font-medium leading-none text-[#1a1a1a]/55 tabular-nums">
+                        {heatCount}
+                      </span>
+                    )}
+                  </div>
                 )
               })}
             </>


### PR DESCRIPTION
## What

`/impeccable audit` follow-through — #85. The availability heatmap encoded consensus **purely as green saturation**, so colorblind responders (and anyone on a phone, where the hover-only count tooltip never fires) couldn't tell how many people were free in a slot. WCAG 1.4.1 (Use of Color) failure on the signature component.

## Change

Render the respondent count as a small, quiet number centered in each cell that has responses, in both `AvailGrid` and `SchedulingGrid`. Suppressed in the single-person focused view (where every cell would just read "1"). This is the **visual** half of the redundant cue; the **screen-reader** half (per-cell `aria-label` announcing the count) shipped in #86.

## Verification

- `npm run build` passes.
- ⚠️ **Not eyeballed live** — worth a look that the number stays legible across the saturation range and doesn't crowd narrow mobile cells (it's intentionally subtle at 10px / 55% ink; `/impeccable polish` can tune if needed).

## Scope note

Remaining: #87 (hero copy), #88 (PollCreator), #51 (confirm dialogs), then `/impeccable polish`.

Closes #85
