### PR TITLE
fix(landing): lead the hero with the group-scheduling job, not AI/MCP (#87)

### DIFF
--- a/client/src/pages/Landing.jsx
+++ b/client/src/pages/Landing.jsx
@@ -154,15 +154,16 @@ export default function Landing() {
               </a>
 
               <h1 className="text-4xl sm:text-6xl leading-[1.1] font-bold text-[#1a1a1a] tracking-tight">
-                Let your AI<br/>
-                find a time that<br/>
-                works for everyone
+                Find a time your<br/>
+                whole group can<br/>
+                actually meet
               </h1>
 
               <p className="text-xl text-[#6b6560] leading-relaxed max-w-lg">
-                Connect avails to Claude, Cursor, or any MCP-compatible tool.
-                Create polls, check availability, and schedule meetings — all
-                from your terminal. Built on ATProto so your data stays yours.
+                avails is a free, open scheduling poll for groups. Share a link,
+                everyone marks when they're free, and you pick the time that
+                works for the most people. No accounts to chase, and your data
+                stays yours.
               </p>
 
               <div className="flex items-center gap-4 pt-2">
@@ -170,12 +171,6 @@ export default function Landing() {
               </div>
 
               <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3 sm:gap-8 pt-6 text-base text-[#6b6560]">
-                <div className="flex items-center gap-2.5">
-                  <svg width="20" height="20" viewBox="0 0 16 16" fill="none" stroke="#0d9488" strokeWidth="1.5">
-                    <path d="M5 3l-1 10M12 3l-1 10M3 6h11M2 10h11"/>
-                  </svg>
-                  AI assistant ready
-                </div>
                 <div className="flex items-center gap-2.5">
                   <svg width="20" height="20" viewBox="0 0 16 16" fill="none" stroke="#0d9488" strokeWidth="1.5">
                     <circle cx="8" cy="8" r="6"/>
@@ -187,14 +182,20 @@ export default function Landing() {
                   <svg width="20" height="20" viewBox="0 0 16 16" fill="none" stroke="#0d9488" strokeWidth="1.5">
                     <path d="M4 8h8M8 4v8M2 2h4M10 2h4M2 14h4M10 14h4"/>
                   </svg>
-                  ATProto interoperable
+                  Free & open source
                 </div>
                 <div className="flex items-center gap-2.5">
                   <svg width="20" height="20" viewBox="0 0 16 16" fill="none" stroke="#0d9488" strokeWidth="1.5">
                     <rect x="3" y="5" width="10" height="8" rx="1.5"/>
                     <path d="M5 5V3.5a3 3 0 016 0V5"/>
                   </svg>
-                  Can be self-hosted
+                  Your data stays yours
+                </div>
+                <div className="flex items-center gap-2.5">
+                  <svg width="20" height="20" viewBox="0 0 16 16" fill="none" stroke="#0d9488" strokeWidth="1.5">
+                    <path d="M5 3l-1 10M12 3l-1 10M3 6h11M2 10h11"/>
+                  </svg>
+                  Works with Claude & MCP tools
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## What

`/impeccable clarify` — #87. The Landing hero opened with "Let your AI find a time that works for everyone" and a "connect to Claude, Cursor, or any MCP-compatible tool… from your terminal" subhead, positioning avails as a developer tool. PRODUCT.md's primary audience is community/civic organizers escaping corporate SaaS, who shouldn't be greeted by "Let your AI."

## Change (user-approved copy)

- **H1:** "Find a time your whole group can actually meet"
- **Subhead:** leads with the communal job (share a link, everyone marks availability, pick the time that works for the most people) and keeps the data-sovereignty point.
- **AI/MCP demoted** from the lead to one feature pill ("Works with Claude & MCP tools"); pills reordered so "Respond without logging in" comes first.
- Removed the em dash from the subhead (DESIGN.md bans em dashes in UI copy).

Copy direction was chosen by the user from three options before implementing (public-surface prose = propose-first).

## Verification

- `npm run build` passes.
- ⚠️ Hero is above-the-fold marketing copy — worth a quick live look at line-breaks/wrapping on mobile once deployed.

## Scope note

Remaining: #88 (PollCreator disclosure), #51 (confirm dialogs), then `/impeccable polish`. The About page's developer framing (protocol pills, `@atproto/lex`) is left as-is — appropriate for an About/OSS page; only the Landing lead needed fixing.

Closes #87
