### PR TITLE
fix(ux): styled dialogs for delete-response and unschedule (#51)

### DIFF
--- a/client/src/components/DeleteResponseDialog.jsx
+++ b/client/src/components/DeleteResponseDialog.jsx
@@ -1,0 +1,61 @@
+import { useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogClose,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+
+// Replaces a bare window.confirm() for deleting one's own availability (#51).
+export default function DeleteResponseDialog({ open, onOpenChange, onConfirm }) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  async function handleConfirm() {
+    setLoading(true)
+    setError(null)
+    try {
+      await onConfirm()
+      onOpenChange(false)
+    } catch (err) {
+      setError(err.message || 'Could not delete your availability.')
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-white">
+        <DialogHeader>
+          <DialogTitle className="text-[#1a1a1a]">Delete your availability?</DialogTitle>
+        </DialogHeader>
+        <p className="text-base text-[#6b6560]">
+          This removes your response from this poll. The poll stays open, so you can add your availability again any time.
+        </p>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button
+              type="button"
+              variant="outline"
+              className="border-[#e8e5df] text-[#6b6560] hover:bg-[#f0eeea] hover:text-[#1a1a1a] text-base px-5 py-2 rounded-lg"
+              disabled={loading}
+            >
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button
+            onClick={handleConfirm}
+            disabled={loading}
+            className="bg-red-600 text-white hover:bg-red-700 text-base px-6 py-3 rounded-lg transition-colors"
+          >
+            {loading ? 'Deleting...' : 'Delete availability'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/client/src/components/UnscheduleDialog.jsx
+++ b/client/src/components/UnscheduleDialog.jsx
@@ -1,0 +1,66 @@
+import { useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogClose,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+
+// Replaces the multi-paragraph window.confirm() for unscheduling a meeting (#51).
+// Copy preserved from the original confirm; `published` / `hasGoogleEvent` gate
+// the consequence lines.
+export default function UnscheduleDialog({ open, onOpenChange, onConfirm, published, hasGoogleEvent }) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  async function handleConfirm() {
+    setLoading(true)
+    setError(null)
+    try {
+      await onConfirm()
+      onOpenChange(false)
+    } catch (err) {
+      setError(err.message || 'Could not unschedule the meeting.')
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-white">
+        <DialogHeader>
+          <DialogTitle className="text-[#1a1a1a]">Unschedule this meeting?</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-2 text-base text-[#6b6560]">
+          <p>Participants with emails will get a calendar-cancel message so the event disappears from their calendars.</p>
+          {published && <p>The OpenMeet event will also be deleted.</p>}
+          {hasGoogleEvent && <p>The Google Calendar event will also be removed.</p>}
+          <p>The poll will reopen and you can pick a different time.</p>
+        </div>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button
+              type="button"
+              variant="outline"
+              className="border-[#e8e5df] text-[#6b6560] hover:bg-[#f0eeea] hover:text-[#1a1a1a] text-base px-5 py-2 rounded-lg"
+              disabled={loading}
+            >
+              Keep it scheduled
+            </Button>
+          </DialogClose>
+          <Button
+            onClick={handleConfirm}
+            disabled={loading}
+            className="bg-red-600 text-white hover:bg-red-700 text-base px-6 py-3 rounded-lg transition-colors"
+          >
+            {loading ? 'Unscheduling...' : 'Unschedule'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/client/src/pages/PollView.jsx
+++ b/client/src/pages/PollView.jsx
@@ -20,6 +20,8 @@ import PollHeader from '@/components/PollHeader'
 import ResponsePanel from '@/components/ResponsePanel'
 import EditPollDialog from '@/components/EditPollDialog'
 import DeletePollDialog from '@/components/DeletePollDialog'
+import DeleteResponseDialog from '@/components/DeleteResponseDialog'
+import UnscheduleDialog from '@/components/UnscheduleDialog'
 import GuestModal from '@/components/GuestModal'
 
 const EMPTY_SET = new Set()
@@ -65,6 +67,8 @@ export default function PollView() {
   const [schedulingError, setSchedulingError] = useState(null)
   const [showEditPoll, setShowEditPoll] = useState(false)
   const [showDeletePoll, setShowDeletePoll] = useState(false)
+  const [showDeleteResponse, setShowDeleteResponse] = useState(false)
+  const [showUnschedule, setShowUnschedule] = useState(false)
   const [showGuestModal, setShowGuestModal] = useState(false)
   const [openmeetUrl, setOpenmeetUrl] = useState(null)
   const [publishingToOpenMeet, setPublishingToOpenMeet] = useState(false)
@@ -373,21 +377,22 @@ export default function PollView() {
     setSubmitted(false)
   }
 
-  async function handleDeleteResponse() {
+  function handleDeleteResponse() {
     if (!responseRkey) return
-    if (!confirm('Delete your availability?')) return
-    try {
-      await deleteResponse(did, rkey, responseRkey)
-      setResponseRkey(null)
-      setMySlots(new Set())
-      setSubmitted(false)
-      setParticipant(null)
-      localStorage.removeItem(`avails:response:${window.location.pathname}`)
-      const updated = await getPoll(did, rkey)
-      setResponses(normalizeResponses(updated.responses))
-    } catch (err) {
-      setSubmitError(err.message)
-    }
+    setShowDeleteResponse(true)
+  }
+
+  // Actual deletion — runs from the dialog's confirm. Throwing surfaces the
+  // error inline in the dialog rather than leaving it silent.
+  async function confirmDeleteResponse() {
+    await deleteResponse(did, rkey, responseRkey)
+    setResponseRkey(null)
+    setMySlots(new Set())
+    setSubmitted(false)
+    setParticipant(null)
+    localStorage.removeItem(`avails:response:${window.location.pathname}`)
+    const updated = await getPoll(did, rkey)
+    setResponses(normalizeResponses(updated.responses))
   }
 
   async function insertGoogleEvent({ finalTime, finalDuration, tokenOverride }) {
@@ -479,31 +484,21 @@ export default function PollView() {
     }
   }
 
-  async function handleUnschedule() {
-    const published = !!poll?.openmeetEventSlug || !!openmeetUrl
-    const hasGoogleEvent = !!poll?.googleEventId && !!poll?.googleCalendarId
-    const parts = [
-      'Unschedule this meeting?',
-      '',
-      'Participants with emails will get a calendar-cancel message so the event disappears from their calendars.',
-    ]
-    if (published) parts.push('The OpenMeet event will also be deleted.')
-    if (hasGoogleEvent) parts.push('The Google Calendar event will also be removed.')
-    parts.push('', 'The poll will reopen and you can pick a different time.')
-    if (!confirm(parts.join('\n'))) return
+  function handleUnschedule() {
+    setShowUnschedule(true)
+  }
 
+  // Actual unschedule — runs from the dialog's confirm. unfinalizePoll throwing
+  // surfaces inline in the dialog; the Google deletion below stays best-effort
+  // (must never roll back the unschedule — see CLAUDE.md).
+  async function confirmUnschedule() {
     // Capture before unfinalize strips them from the record
     const googleEventId = poll?.googleEventId
     const googleCalendarId = poll?.googleCalendarId
 
-    try {
-      await unfinalizePoll(did, rkey)
-      setOpenmeetUrl(null)
-      setOpenmeetError(null)
-    } catch (err) {
-      alert(`Could not unschedule: ${err.message}`)
-      return
-    }
+    await unfinalizePoll(did, rkey)
+    setOpenmeetUrl(null)
+    setOpenmeetError(null)
 
     // Best-effort: remove the Google Calendar event. Failure here doesn't roll back the unschedule.
     if (googleEventId && googleCalendarId) {
@@ -519,7 +514,7 @@ export default function PollView() {
         await deleteEvent(token, googleCalendarId, googleEventId)
       } catch (err) {
         console.warn('[avails] deleteEvent on unschedule failed:', err)
-        alert("Schedule cancelled. Couldn't remove the event from Google Calendar — please delete it manually.")
+        alert("Schedule cancelled. Couldn't remove the event from Google Calendar. Please delete it manually.")
       }
     }
 
@@ -854,6 +849,20 @@ export default function PollView() {
         onOpenChange={setShowDeletePoll}
         did={did}
         rkey={rkey}
+      />
+
+      <DeleteResponseDialog
+        open={showDeleteResponse}
+        onOpenChange={setShowDeleteResponse}
+        onConfirm={confirmDeleteResponse}
+      />
+
+      <UnscheduleDialog
+        open={showUnschedule}
+        onOpenChange={setShowUnschedule}
+        onConfirm={confirmUnschedule}
+        published={!!poll?.openmeetEventSlug || !!openmeetUrl}
+        hasGoogleEvent={!!poll?.googleEventId && !!poll?.googleCalendarId}
       />
 
       <GuestModal


### PR DESCRIPTION
## What

#51 — destructive responder/creator actions used bare browser `confirm()` dialogs: unstyled, no reassurance, and for unschedule, genuinely thoughtful multi-paragraph copy trapped in a system alert that reads like an error. The design-critique personas flagged this as a trust break at the highest-anxiety moments ("warm, human, communal" — a browser confirm is none of those).

## Change

- **`DeleteResponseDialog`** — styled confirm for "Delete your availability?", with reassurance that the poll stays open and they can re-add any time.
- **`UnscheduleDialog`** — styled confirm that **preserves the original consequence copy** (calendar-cancel emails, conditional OpenMeet/Google-event removal, "the poll will reopen"), with a "Keep it scheduled" cancel.
- Both mirror the existing `DeletePollDialog` pattern (the codebase's convention; no new shadcn component pulled in). Errors now surface **inline in the dialog** instead of a separate `alert()`.
- The Google-event deletion stays **best-effort** — never rolls back the unschedule (CLAUDE.md hard constraint preserved).
- Fixed an em dash in the residual Google-deletion alert (DESIGN.md).

The unschedule copy was preserved rather than rewritten (it was already good), so no new prose to approve.

## Verification

- `npm run build` passes.
- ⚠️ Not eyeballed live — worth confirming both dialogs open from their triggers (Delete availability / Unschedule in the poll header menu), cancel cleanly, and that the unschedule consequence lines show/hide correctly based on whether the poll was published to OpenMeet / has a Google event.

## Scope note

This was the last tracked critique item. Next: `/impeccable polish` as the final consistency/edge-state sweep, then a re-run of `/impeccable critique` to see the 26/40 move.

Closes #51
