### PR TITLE
fix(mcp): pass generateIcs an object, not positional args (#105)

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "node --watch src/index.js",
     "start": "node src/index.js",
-    "test": "node --test test/validate.test.js test/membership.test.js test/mcp-share-poll.test.js test/mcp-list-communities.test.js && node --experimental-test-module-mocks --test test/responses.test.js"
+    "test": "node --test test/validate.test.js test/membership.test.js test/mcp-share-poll.test.js test/mcp-list-communities.test.js && node --experimental-test-module-mocks --test test/responses.test.js test/mcp-schedule-ics.test.js"
   },
   "license": "AGPL-3.0",
   "dependencies": {

--- a/server/src/mcp/tools.js
+++ b/server/src/mcp/tools.js
@@ -523,7 +523,7 @@ async function schedule({ did, rkey, finalTime, finalDuration }, authContext) {
 
     const url = pollUrl(did, rkey);
     const participants = responses.filter((r) => r.name).map((r) => r.name);
-    const icsContent = generateIcs(updatedRecord, url, participants);
+    const icsContent = generateIcs({ poll: updatedRecord, pollUrl: url, did, rkey, participants });
     const icsBase64 = Buffer.from(icsContent).toString('base64');
 
     const emailAddresses = responses

--- a/server/test/mcp-schedule-ics.test.js
+++ b/server/test/mcp-schedule-ics.test.js
@@ -1,0 +1,125 @@
+/**
+ * Regression tests for the `schedule` MCP tool's calendar-invite path (#105).
+ *
+ * `schedule` called generateIcs(updatedRecord, url, participants) positionally,
+ * but generateIcs takes a single destructured object — so `poll` resolved to
+ * `updatedRecord.poll` (undefined) and `new Date(poll.finalTime)` threw. The
+ * call sits above the email filter, so it threw on EVERY finalize whose
+ * responses fetch succeeded, not only ones with participant emails — and it
+ * threw *after* the record was already written to the PDS, leaving the poll
+ * finalized but the tool errored.
+ *
+ * Requires --experimental-test-module-mocks (mock.module below), so this file
+ * belongs in the second (mock) group in package.json's test script.
+ */
+
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.CLIENT_URL = 'https://avails.test';
+
+const DID = 'did:plc:creator';
+const RKEY = 'poll1';
+const PDS = 'https://pds.test';
+const POLL_URI = `at://${DID}/chat.avails.scheduling.poll/${RKEY}`;
+
+let sendEmailCalls;
+
+mock.module('../src/lib/email.js', {
+  namedExports: {
+    sendEmail: async (opts) => {
+      sendEmailCalls.push(opts);
+      return { id: 'mock-email' };
+    },
+  },
+});
+
+// Response records the mocked PDS listRecords returns; each test sets these.
+let responseRecords;
+
+globalThis.fetch = async (url) => {
+  const u = String(url);
+  if (u.startsWith('https://plc.directory/')) {
+    return {
+      ok: true,
+      json: async () => ({
+        service: [{ id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: PDS }],
+      }),
+    };
+  }
+  if (u.includes('com.atproto.repo.getRecord')) {
+    return {
+      ok: true,
+      json: async () => ({
+        cid: 'cid-existing',
+        value: {
+          title: 'Weekly sync',
+          description: 'Agenda in the doc',
+          timezone: 'UTC',
+          status: 'open',
+          createdAt: '2026-07-01T00:00:00.000Z',
+        },
+      }),
+    };
+  }
+  if (u.includes('com.atproto.repo.listRecords')) {
+    return { ok: true, json: async () => ({ records: responseRecords }) };
+  }
+  throw new Error(`Unexpected fetch() call in schedule ICS test: ${u}`);
+};
+
+const { callTool } = await import('../src/mcp/tools.js');
+
+function authContext() {
+  return {
+    did: DID,
+    oauthSession: {
+      fetchHandler: async () => ({ ok: true, json: async () => ({}) }),
+    },
+  };
+}
+
+const ARGS = {
+  did: DID,
+  rkey: RKEY,
+  finalTime: '2026-07-21T14:00:00.000Z',
+  finalDuration: 60,
+};
+
+describe('schedule MCP tool — calendar invite (#105)', () => {
+  it('finalizes without throwing when no participant supplied an email', async () => {
+    sendEmailCalls = [];
+    responseRecords = [{ value: { pollUri: POLL_URI, name: 'Alice' } }];
+
+    const result = JSON.parse(await callTool('schedule', ARGS, authContext()));
+
+    assert.equal(result.scheduled, true);
+    assert.equal(result.emailsSent, 0);
+    assert.deepEqual(sendEmailCalls, []);
+  });
+
+  it('attaches a valid ICS invite when a participant supplied an email', async () => {
+    sendEmailCalls = [];
+    responseRecords = [
+      { value: { pollUri: POLL_URI, name: 'Alice', email: 'alice@test.dev' } },
+      { value: { pollUri: POLL_URI, name: 'Bob' } },
+    ];
+
+    const result = JSON.parse(await callTool('schedule', ARGS, authContext()));
+
+    assert.equal(result.scheduled, true);
+    assert.equal(result.emailsSent, 1);
+    assert.equal(sendEmailCalls.length, 1);
+    assert.equal(sendEmailCalls[0].to, 'alice@test.dev');
+
+    const ics = Buffer.from(sendEmailCalls[0].attachments[0].content, 'base64').toString('utf8');
+    assert.match(ics, /BEGIN:VCALENDAR/);
+    assert.match(ics, /SUMMARY:Weekly sync/);
+    assert.match(ics, /DTSTART:20260721T140000Z/);
+    // Deterministic UID must resolve from did/rkey, not "avails-undefined-undefined@…"
+    assert.match(ics, /UID:avails-did:plc:creator-poll1@avails\.test/);
+    assert.doesNotMatch(ics, /undefined/);
+    // Participants are surfaced in the description, proving they were passed through.
+    assert.match(ics, /Alice/);
+  });
+});


### PR DESCRIPTION
Fixes #105.

The `schedule` MCP tool passed **positional** args to `generateIcs`, which destructures a single object. So `poll` resolved to `updatedRecord.poll` (`undefined`) and `new Date(poll.finalTime)` threw a `TypeError`.

```js
- const icsContent = generateIcs(updatedRecord, url, participants);
+ const icsContent = generateIcs({ poll: updatedRecord, pollUrl: url, did, rkey, participants });
```

## The issue understated the severity

#105 says it throws "whenever at least one participant supplied an email." It's worse than that:

- The `generateIcs` call sits **above** the email filter, inside `if (responsesRes.ok)`. `listRecords` returns `{records: []}` even with zero responses, so the block is entered and the call throws **on every finalize whose responses fetch succeeds** — emails or not.
- It throws **after** `putRecord` (line 503) and `updatePollStatus` (line 511) have already run. So the poll **is** finalized in the PDS, but the tool returns an error — a partial-success failure where the caller can't tell the write landed.

The only non-throwing path was the responses fetch failing.

Passing `did`/`rkey` through also fixes the deterministic UID, which was resolving to `avails-undefined-undefined@<host>`. Calendar apps need that UID stable to match a later `METHOD:CANCEL` back to the original invite.

**Not affected:** the REST finalize path (`routes/polls.js`) already used the object form.

## Tests

New `server/test/mcp-schedule-ics.test.js`, registered in the mock group of the test script:

1. **finalize with no participant emails** — proves the throw fires without any email involved (the case #105 missed).
2. **finalize with a participant email** — asserts the attached ICS is valid, carries the resolved UID `avails-did:plc:creator-poll1@avails.test`, the right `DTSTART`, and contains no `undefined`.

Both failed with the reported `TypeError` before the fix; suite is green after (51 tests, up from 49).

## Merge note

This branches off `main` and is independent of #104 — but both edit the `"test"` script line in `server/package.json`, so **whichever merges second will hit a one-line conflict there**. Resolution is the union of the two test-file lists.

The `tools.js` change itself won't conflict: #104 doesn't touch that line.
