### PR TITLE
ci: run the server test suite, glob the syntax check (#108)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,16 +18,19 @@ jobs:
         run: cd client && npm install
       - name: Build client
         run: cd client && npm run build
-      - name: Check server syntax
+      - name: Install server dependencies
+        run: cd server && npm ci
+      - name: Server tests
+        working-directory: server
+        shell: bash
         run: |
-          node --check server/src/index.js
-          node --check server/src/routes/auth.js
-          node --check server/src/routes/polls.js
-          node --check server/src/routes/responses.js
-          node --check server/src/routes/communities.js
-          node --check server/src/lib/sessionStore.js
-          node --check server/src/lib/pollIndex.js
-          node --check server/src/lib/email.js
-          node --check server/src/lib/ical.js
-          node --check server/src/lib/persistence.js
-          node --check server/src/middleware/auth.js
+          set -o pipefail
+          npm test 2>&1 | tee /tmp/server-tests.log
+          # `node --test` exits 0 reporting "pass 0" when its pattern matches no
+          # files — so a glob that stops expanding (different Node version, moved
+          # directory, renamed files) would leave this step green having run
+          # nothing at all. Fail loudly instead.
+          grep -qE 'pass [1-9]' /tmp/server-tests.log \
+            || { echo "::error::No tests ran — check the test glob in server/package.json"; exit 1; }
+      - name: Check server syntax
+        run: find server/src -name '*.js' -not -path '*/lexicons/*' -exec node --check {} +

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,14 +21,14 @@ npx @atproto/lex build --lexicons ./lexicons --out ./server/src/lexicons --index
 
 ```bash
 # Tests (Node built-in test runner, no extra dependencies)
-cd server && npm test                     # All tests (validation + route integration)
+cd server && npm test                     # Whole server suite
 ```
 
-Server syntax check: `node --check server/src/index.js`
+Server syntax check (what CI runs): `find server/src -name '*.js' -not -path '*/lexicons/*' -exec node --check {} +`
 
-Tests use Node's built-in test runner (`node:test` + `node:assert`). Integration tests require `--experimental-test-module-mocks` for module mocking. Two test files:
-- `test/validate.test.js` — unit tests for all validation middleware (31 tests)
-- `test/responses.test.js` — integration tests for response routes with mocked PDS/session layer (10 tests)
+Tests use Node's built-in test runner (`node:test` + `node:assert`). The `test` script globs `test/*.test.js`, so **a new test file is gated automatically — never register one by hand.** `--experimental-test-module-mocks` is passed to the whole suite (inert for files that don't call `mock.module`), and Node runs each file in its own process, so per-file `globalThis.fetch` stubs don't leak between them.
+
+**CI runs the full suite and asserts at least one test passed.** `node --test` exits 0 reporting `pass 0` when its glob matches nothing, so a pattern that quietly stops expanding would otherwise leave CI green having run nothing — the guard in `ci.yml` is what makes that fail loudly.
 
 The **client has no test runner** — `cd client && npm run build` is the only client-side gate.
 

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "node --watch src/index.js",
     "start": "node src/index.js",
-    "test": "node --test test/validate.test.js test/availabilityValidate.test.js test/membership.test.js test/mcp-share-poll.test.js test/mcp-list-communities.test.js test/listMembers.test.js test/availabilityOverlap.test.js && node --experimental-test-module-mocks --test test/responses.test.js test/availability.route.test.js test/scheduleCall.test.js test/mcp-schedule-ics.test.js"
+    "test": "node --experimental-test-module-mocks --test \"test/*.test.js\""
   },
   "license": "AGPL-3.0",
   "dependencies": {


### PR DESCRIPTION
Fixes #108.

CI built the client and ran `node --check` over 11 hardcoded server files. It never ran `npm test` — the whole 93-test server suite was ungated.

That's why #105 shipped: a runtime `TypeError` in `mcp/tools.js`, a file that wasn't even in the check list. And it's why today's #104/#107 conflict had to be hand-verified — the conflicted line *was* the list of tests that run, so CI was structurally blind to a resolution that dropped one.

## Changes

- **Install server deps + run the suite.** `npm ci` (lockfile verified in sync) then `npm test`. CI never installed server deps before — only the client's — which is presumably why `node --check` was chosen: it parses without resolving imports.
- **Glob the syntax check.** `find server/src -name '*.js' -not -path '*/lexicons/*' -exec node --check {} +` — **26 files covered, up from 11**, including all of `mcp/`. Hardcoding the list is exactly why `mcp/` silently fell out of coverage as the codebase grew.
- **Collapse the test script to one globbed command:**
  ```
  node --experimental-test-module-mocks --test "test/*.test.js"
  ```
  The two-group split existed only to pass `--experimental-test-module-mocks` to some files. The flag is inert for files that don't call `mock.module`, and Node runs each file in its own process, so per-file `globalThis.fetch` stubs don't leak. **New test files are now gated automatically.** That hand-registration line is also what conflicted between #104 and #107 — it can't conflict again.

## The guard, and why it's here

`node --test` **exits 0 reporting `pass 0` when its pattern matches nothing.** A glob that quietly stops expanding — different Node version, moved directory, renamed files — would leave CI green having run no tests at all. That's strictly worse than today: CI would *claim* the suite was gated while running nothing.

So the step fails unless at least one test passed. Verified both directions locally:

| case | `node --test` exit | guard |
|---|---|---|
| real run | 0, `pass 93` | passes |
| glob matches nothing | **0**, `pass 0` | **trips → CI fails** |

The quoted glob is deliberate: Node expands it internally, so it also works where the shell doesn't glob (npm runs scripts through `cmd` on Windows). Locally that's verified on Node 24; CI is Node 22, and if the pattern ever behaves differently there, the guard turns it into a loud failure rather than a silent pass.

## Verification

- `npm test` → **93/93** via the new script
- `find … -exec node --check {} +` → exit 0 across all 26 files (`node --check` handles ESM)
- `ci.yml` parses as valid YAML, 7 steps
- `npm ci --dry-run` in `server/` → "up to date" (#104 updated the lockfile with `luxon` correctly)

## Not included

Client still uses `npm install` rather than `npm ci` — left alone to keep this diff to the issue's scope. Worth a follow-up.

`CLAUDE.md`'s test section is updated in this PR since the change makes it stale. It was already wrong — it claimed "Two test files" when there are 11 — so it's now written to describe the shape rather than counts, which is what rotted.
