### PR TITLE
fix(mcp): include the list owner in schedule_call's fan-out (#110)

### DIFF
--- a/server/src/mcp/listMembers.js
+++ b/server/src/mcp/listMembers.js
@@ -38,8 +38,11 @@ async function resolvePds(did) {
   return svc?.serviceEndpoint || 'https://bsky.social';
 }
 
-// Validates `at://<did>/app.bsky.graph.list/<rkey>` shape. Throws otherwise.
-function assertListUri(listUri) {
+// Validates `at://<did>/app.bsky.graph.list/<rkey>` shape and returns the
+// authority DID, which is the list's owner — a record can only live in its
+// own creator's repo, so this holds without trusting any API response shape.
+// Throws otherwise.
+function parseListUri(listUri) {
   if (typeof listUri !== 'string' || !listUri.startsWith('at://')) {
     throw new Error(`Invalid list URI: ${listUri}`);
   }
@@ -48,6 +51,7 @@ function assertListUri(listUri) {
   if (!did || collection !== LIST_COLLECTION || !rkey) {
     throw new Error(`Not an ${LIST_COLLECTION} URI: ${listUri}`);
   }
+  return did;
 }
 
 // Pages app.bsky.graph.getList on the public AppView until the cursor is
@@ -112,17 +116,24 @@ async function resolveMemberRecord(did, listUri) {
 // have published for that list. Per-member failures (PDS resolution or
 // listRecords) are non-fatal — that member is skipped, not the whole call.
 export async function resolveListAvailability(listUri) {
-  assertListUri(listUri);
+  const ownerDid = parseListUri(listUri);
 
-  const memberDids = await fetchListMemberDids(listUri);
+  // getList never returns a list's owner among its items, and Bluesky's UI
+  // refuses to let an owner add themselves — so without this the person
+  // curating a group's list can never be scheduled through it (#110).
+  // Including them unconditionally is safe because opt-in is expressed by the
+  // record's scope, not by list membership: an owner who published no record
+  // for this list is filtered out by resolveMemberRecord and contributes
+  // nothing, so admins curating a roster they aren't part of are unaffected.
+  const dids = [...new Set([ownerDid, ...(await fetchListMemberDids(listUri))])];
 
   const outcomes = await Promise.allSettled(
-    memberDids.map((did) => resolveMemberRecord(did, listUri))
+    dids.map((did) => resolveMemberRecord(did, listUri))
   );
 
   const results = [];
   outcomes.forEach((outcome, i) => {
-    const did = memberDids[i];
+    const did = dids[i];
     if (outcome.status === 'fulfilled') {
       if (outcome.value) results.push({ did, record: outcome.value });
     } else {

--- a/server/test/listMembers.test.js
+++ b/server/test/listMembers.test.js
@@ -167,6 +167,9 @@ describe('resolveListAvailability', () => {
       if (u.includes('com.atproto.repo.listRecords')) {
         const params = new URL(u).searchParams;
         const repo = params.get('repo');
+        // LIST_URI's authority is the owner, who is now always queried (#110).
+        // This test is about pagination, so the owner publishes nothing.
+        if (repo === 'did:plc:creator') return { ok: true, json: async () => ({ records: [] }) };
         return { ok: true, json: async () => ({ records: [availabilityRecord(repo)] }) };
       }
       throw new Error(`Unexpected fetch: ${u}`);
@@ -188,6 +191,11 @@ describe('resolveListAvailability', () => {
         return { ok: true, json: async () => pdsDoc('https://pds.gina.example') };
       }
       if (u.includes('com.atproto.repo.listRecords')) {
+        // The owner (LIST_URI's authority) is now always queried (#110); this
+        // test is about picking the latest record, so they publish nothing.
+        if (new URL(u).searchParams.get('repo') === 'did:plc:creator') {
+          return { ok: true, json: async () => ({ records: [] }) };
+        }
         return {
           ok: true,
           json: async () => ({
@@ -236,6 +244,11 @@ describe('resolveListAvailability', () => {
         return { ok: true, json: async () => pdsDoc('https://pds.ok.example') };
       }
       if (u.includes('com.atproto.repo.listRecords')) {
+        // The owner (LIST_URI's authority) is now always queried (#110); this
+        // test is about skipping a broken member, so they publish nothing.
+        if (new URL(u).searchParams.get('repo') === 'did:plc:creator') {
+          return { ok: true, json: async () => ({ records: [] }) };
+        }
         return { ok: true, json: async () => ({ records: [availabilityRecord('did:plc:ok')] }) };
       }
       throw new Error(`Unexpected fetch: ${u}`);
@@ -244,6 +257,103 @@ describe('resolveListAvailability', () => {
     const result = await resolveListAvailability(LIST_URI);
     assert.equal(result.length, 1);
     assert.equal(result[0].did, 'did:plc:ok');
+  });
+
+  it('(h) includes the list owner, whom getList never returns among items (#110)', async () => {
+    // Bluesky omits a list's owner from getList items and its UI refuses to let
+    // an owner add themselves, so the person curating a group's list was never
+    // queried — the organizer could not be scheduled through their own list.
+    // LIST_URI's authority (did:plc:creator) IS the owner: a list record can
+    // only live in its creator's repo.
+    fetchImpl = async (url) => {
+      const u = String(url);
+      if (u.includes('app.bsky.graph.getList')) {
+        return {
+          ok: true,
+          json: async () => ({
+            list: { uri: LIST_URI, creator: { did: 'did:plc:creator' } },
+            items: [{ subject: { did: 'did:plc:alice' } }], // owner absent, as bsky does it
+          }),
+        };
+      }
+      if (u.startsWith('https://plc.directory/')) {
+        const did = decodeURIComponent(u.replace('https://plc.directory/', ''));
+        return { ok: true, json: async () => pdsDoc(`https://pds.${did.split(':').pop()}.example`) };
+      }
+      if (u.includes('com.atproto.repo.listRecords')) {
+        const repo = new URL(u).searchParams.get('repo');
+        return { ok: true, json: async () => ({ records: [availabilityRecord(repo)] }) };
+      }
+      throw new Error(`Unexpected fetch: ${u}`);
+    };
+
+    const result = await resolveListAvailability(LIST_URI);
+    const dids = result.map((r) => r.did).sort();
+    assert.deepEqual(dids, ['did:plc:alice', 'did:plc:creator']);
+  });
+
+  it('(i) does not double-count an owner who also appears in items', async () => {
+    // The Bluesky UI blocks self-add, but the protocol does not — a listitem
+    // record naming the owner is writable directly, so dedupe rather than
+    // resolve the same PDS twice and report them as two participants.
+    let creatorRecordFetches = 0;
+    fetchImpl = async (url) => {
+      const u = String(url);
+      if (u.includes('app.bsky.graph.getList')) {
+        return {
+          ok: true,
+          json: async () => ({
+            list: { uri: LIST_URI, creator: { did: 'did:plc:creator' } },
+            items: [{ subject: { did: 'did:plc:creator' } }], // owner self-added
+          }),
+        };
+      }
+      if (u.startsWith('https://plc.directory/')) {
+        return { ok: true, json: async () => pdsDoc('https://pds.creator.example') };
+      }
+      if (u.includes('com.atproto.repo.listRecords')) {
+        creatorRecordFetches += 1;
+        return { ok: true, json: async () => ({ records: [availabilityRecord('did:plc:creator')] }) };
+      }
+      throw new Error(`Unexpected fetch: ${u}`);
+    };
+
+    const result = await resolveListAvailability(LIST_URI);
+    assert.equal(result.length, 1, 'owner must appear once, not twice');
+    assert.equal(result[0].did, 'did:plc:creator');
+    assert.equal(creatorRecordFetches, 1, 'owner PDS should be queried once');
+  });
+
+  it('(j) an owner who published no record for this list contributes nothing', async () => {
+    // Opt-in is the record's scope, not list membership — so an admin curating
+    // a roster they are not part of stays absent, exactly as before.
+    fetchImpl = async (url) => {
+      const u = String(url);
+      if (u.includes('app.bsky.graph.getList')) {
+        return {
+          ok: true,
+          json: async () => ({
+            list: { uri: LIST_URI, creator: { did: 'did:plc:creator' } },
+            items: [{ subject: { did: 'did:plc:alice' } }],
+          }),
+        };
+      }
+      if (u.startsWith('https://plc.directory/')) {
+        const did = decodeURIComponent(u.replace('https://plc.directory/', ''));
+        return { ok: true, json: async () => pdsDoc(`https://pds.${did.split(':').pop()}.example`) };
+      }
+      if (u.includes('com.atproto.repo.listRecords')) {
+        const repo = new URL(u).searchParams.get('repo');
+        if (repo === 'did:plc:creator') {
+          return { ok: true, json: async () => ({ records: [] }) }; // admin, not a participant
+        }
+        return { ok: true, json: async () => ({ records: [availabilityRecord(repo)] }) };
+      }
+      throw new Error(`Unexpected fetch: ${u}`);
+    };
+
+    const result = await resolveListAvailability(LIST_URI);
+    assert.deepEqual(result.map((r) => r.did), ['did:plc:alice']);
   });
 
   it('(g) a member whose fetch times out (AbortError) is skipped, not fatal to the whole call', async () => {
@@ -276,6 +386,11 @@ describe('resolveListAvailability', () => {
         return { ok: true, json: async () => pdsDoc('https://pds.fast.example') };
       }
       if (u.includes('com.atproto.repo.listRecords')) {
+        // The owner (LIST_URI's authority) is now always queried (#110); this
+        // test is about skipping a hung member, so they publish nothing.
+        if (new URL(u).searchParams.get('repo') === 'did:plc:creator') {
+          return { ok: true, json: async () => ({ records: [] }) };
+        }
         return { ok: true, json: async () => ({ records: [availabilityRecord('did:plc:fast')] }) };
       }
       throw new Error(`Unexpected fetch: ${u}`);


### PR DESCRIPTION
Fixes #110.

`getList` never returns a list's owner among its items, and Bluesky's UI refuses to let an owner add themselves — so the person curating a group's list could never be scheduled through it. `schedule_call` would book a slot for everyone *except* the organizer who most likely called the meeting.

Found by the Phase 1 real-protocol smoke: a valid, unexpired record scoped to exactly the queried list sat on the owner's PDS while `schedule_call` reported `Only 0 members`.

## The fix

```js
const ownerDid = parseListUri(listUri);
const dids = [...new Set([ownerDid, ...(await fetchListMemberDids(listUri))])];
```

**Derived from the list URI's authority, not `data.list.creator.did`** as #110 originally proposed. A record can only live in its own creator's repo, so the URI authority *is* the owner — structurally guaranteed, with no dependence on the shape of an API response that could change or omit `list`. `assertListUri` already parsed that DID and threw it away; it now returns it (renamed `parseListUri`).

**Safe by construction.** Opt-in is expressed by the record's `scope`, not by list membership — `resolveMemberRecord` already drops records whose scope doesn't match the list. So an owner who published nothing for this list contributes nothing, and admins curating a roster they aren't part of are completely unaffected. Deduped, because the protocol permits a self-`listitem` even though the UI blocks it.

## Tests

| | |
|---|---|
| **(h)** owner included though `getList` omits them | reproduced the bug — failed before the fix with `actual: ['did:plc:alice']` vs `expected: ['did:plc:alice','did:plc:creator']` |
| **(i)** owner not double-counted when also in items | guards the dedupe; can only go red once the union exists |
| **(j)** owner with no record for this list contributes nothing | guards the admin-curating-a-roster case |

**Four existing tests broke, and that's worth reading rather than skimming.** (d)/(e)/(f)/(g) returned an availability record for *any* repo queried, so once the owner was actually fetched they handed it one and it correctly appeared in results. That's the same blind spot that hid the bug in the first place: **no `getList` mock in this file ever included the owner** — the fixtures assumed away the exact step that was wrong, which is why 93 passing tests couldn't see it. Those tests are about pagination, latest-record, and failure-skipping, so their fixtures now say the owner published nothing, keeping each on its own subject rather than muddying its expectations.

96/96 passing. First PR gated by the CI from #111.

## Verifying on production after merge

There's already a real record in place to prove this against — the smoke published one to `zhgnv.com`'s PDS, scoped to the "Standing Avails Test" list, whose owner is that same account. So `schedule_call` on that list should flip:

```
before:  {"booked":false,"reason":"Only 0 members ... have standing availability on record"}
after:   ... coverage.withRecords: 1   (still falls back — 1 < MIN_CALL_COVERAGE)
```

A live before/after on real data, no fixtures involved.
