### PR TITLE
fix(server): 404 unmatched /api GETs instead of hanging (#109)

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -13,6 +13,7 @@ import communityRoutes from './routes/communities.js';
 import openmeetRoutes from './routes/openmeet.js';
 import { startPersistence, markDirty, saveNow } from './lib/persistence.js';
 import { restoreOAuthSessions, sessions } from './lib/sessionStore.js';
+import { spaFallback } from './middleware/spaFallback.js';
 import mcpOauthRoutes from './mcp/oauth.js';
 import { handleMcp, handleMcpDelete } from './mcp/handler.js';
 import { pollOgHandler } from './lib/og.js';
@@ -142,12 +143,8 @@ app.get('/p/:did/:rkey', pollOgHandler(clientDist));
 
 app.use(express.static(clientDist));
 
-// SPA fallback
-app.get('*', (req, res) => {
-  if (!req.path.startsWith('/api')) {
-    res.sendFile(path.join(clientDist, 'index.html'));
-  }
-});
+// SPA fallback — serves the client shell, 404s unmatched /api paths (#109)
+app.get('*', spaFallback(clientDist));
 
 // JSON error handler — all API errors return structured JSON
 app.use((err, req, res, next) => {

--- a/server/src/middleware/spaFallback.js
+++ b/server/src/middleware/spaFallback.js
@@ -1,0 +1,20 @@
+import path from 'path';
+
+// Catch-all that serves the built SPA shell for client routes.
+//
+// Extracted from index.js so it can be tested — index.js calls start() on
+// import, so anything inline there is unreachable from a test.
+//
+// An /api path reaching here matched no route, so it must 404. Returning
+// without responding (and without next()) leaves Express holding the request
+// in-flight with nothing left to run: it hangs until the client gives up while
+// the socket stays open, which is what #109 was. JSON matches the error
+// handler in index.js, which already answers /api failures with { error }.
+export function spaFallback(clientDist) {
+  return (req, res) => {
+    if (req.path.startsWith('/api')) {
+      return res.status(404).json({ error: 'Not found' });
+    }
+    res.sendFile(path.join(clientDist, 'index.html'));
+  };
+}

--- a/server/test/spaFallback.test.js
+++ b/server/test/spaFallback.test.js
@@ -1,0 +1,71 @@
+/**
+ * Regression tests for the SPA fallback (#109).
+ *
+ * The catch-all matched every GET, then for an /api path returned without
+ * calling res.* and without calling next() — Express treats the request as
+ * in-flight and nothing else runs, so it hung until the client gave up while
+ * the socket stayed open (Node's requestTimeout defaults to 300s). Unmatched
+ * /api paths are what scanners probe, so each probe held a connection.
+ *
+ * AbortSignal.timeout is what makes a regression fail fast here: without it a
+ * reintroduced hang would stall the suite rather than fail it.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import { once } from 'node:events';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { spaFallback } from '../src/middleware/spaFallback.js';
+
+describe('SPA fallback (#109)', () => {
+  let server;
+  let port;
+  let clientDist;
+
+  before(async () => {
+    clientDist = fs.mkdtempSync(path.join(os.tmpdir(), 'avails-spa-'));
+    fs.writeFileSync(path.join(clientDist, 'index.html'), '<!doctype html><title>app shell</title>');
+
+    const app = express();
+    // A real API route, so the tests distinguish "matched" from "fell through".
+    app.get('/api/real', (req, res) => res.json({ ok: true }));
+    app.get('*', spaFallback(clientDist));
+
+    server = app.listen(0);
+    await once(server, 'listening');
+    port = server.address().port;
+  });
+
+  after(() => {
+    server?.close();
+    fs.rmSync(clientDist, { recursive: true, force: true });
+  });
+
+  it('an unmatched /api GET returns a JSON 404 rather than hanging', async () => {
+    const res = await fetch(`http://localhost:${port}/api/definitely-not-a-route`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    assert.equal(res.status, 404);
+    assert.deepEqual(await res.json(), { error: 'Not found' });
+  });
+
+  it('does not swallow a real API route', async () => {
+    const res = await fetch(`http://localhost:${port}/api/real`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { ok: true });
+  });
+
+  it('still serves the SPA shell for a client route', async () => {
+    const res = await fetch(`http://localhost:${port}/p/did:plc:abc/rkey1`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    assert.equal(res.status, 200);
+    assert.match(await res.text(), /app shell/);
+  });
+});


### PR DESCRIPTION
Fixes #109.

The SPA fallback matched every GET, then for an `/api` path returned without calling `res.*` **and** without calling `next()`. Express hands the request to a matching handler and considers it in-flight, so nothing else ran — the request hung until the client gave up, with the socket held open the whole time (Node's `requestTimeout` defaults to 300s). Unmatched `/api` paths are exactly what scanners probe, so every probe held a connection.

```js
-app.get('*', (req, res) => {
-  if (!req.path.startsWith('/api')) {
-    res.sendFile(path.join(clientDist, 'index.html'));
-  }
-});
+app.get('*', spaFallback(clientDist));
```

```js
// middleware/spaFallback.js
if (req.path.startsWith('/api')) {
  return res.status(404).json({ error: 'Not found' });
}
res.sendFile(path.join(clientDist, 'index.html'));
```

JSON matches the error handler in `index.js`, which already answers `/api` failures with `{ error }`.

## Why it's extracted

`index.js` calls `start()` on import, so anything inline there can't be reached from a test. The handler moved to `middleware/spaFallback.js` **unchanged first**, so the extraction is provably behaviour-neutral — the two non-`/api` tests passed before the fix was applied, and only the `/api` test flipped.

## Tests

`AbortSignal.timeout` is doing real work here: a hang is the absence of a response, so without a deadline a reintroduced regression would *stall the suite* rather than fail it.

| | before fix | after |
|---|---|---|
| unmatched `/api` GET | **TimeoutError after 3010ms** — hung for the full deadline | **404 JSON in 43ms** |
| real `/api` route | 200 | 200 |
| client route → SPA shell | 200 | 200 |

That 3010ms → 43ms is the fix, and it's why the test is written with a deadline rather than a status assertion alone.

## Scope

**GET-only, as filed.** `app.get('*')` never matched POST, so unmatched non-GET `/api` paths already fell through to Express's built-in 404 and were never affected.

**Not included:** an `app.all('*')` so unmatched non-GET `/api` paths get structured JSON instead of Express's HTML 404. That's a status-shape change rather than the hang, so it's left out — worth a follow-up if the inconsistency bothers you.

## Verification

99/99 passing (96 + 3). The new test file needed **no registration** — the glob from #111 picked it up automatically, which is that change earning its keep one PR later.
