### PR TITLE
fix: Phase 1 fast-follows — validator strictness, scope type, UI date (#106)

### DIFF
--- a/client/src/pages/StandingAvailability.jsx
+++ b/client/src/pages/StandingAvailability.jsx
@@ -57,6 +57,21 @@ function isoToDateInputValue(iso) {
   return `${year}-${month}-${day}`
 }
 
+// Human-readable "until <date>" label for a published record. UTC for the same
+// reason isoToDateInputValue is (see above): validUntil is anchored at UTC
+// midnight, so formatting it in browser-local time renders the previous day for
+// every UTC-negative timezone — the record would read "until Sep 10" to a US
+// user when it expires on Sep 11. Locale-aware, calendar-date pinned to UTC.
+function formatValidUntil(iso) {
+  if (!iso) return ''
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  })
+}
+
 function groupWeeklyByDay(weekly) {
   const byDay = new Map()
   for (const w of weekly) {
@@ -203,6 +218,10 @@ export default function StandingAvailability() {
     setForm(emptyFormState())
     setPublishError(null)
     setResolveError(null)
+    // Cancelling abandons the edit that produced the warning, so it must go too
+    // — otherwise a stale "couldn't clean up the old record" line hangs around
+    // over an unrelated form.
+    setCleanupWarning(null)
   }
 
   async function handlePublish(e) {
@@ -365,7 +384,7 @@ export default function StandingAvailability() {
                             <p className="text-sm text-[#8a8580]">
                               {record.timezone} &middot; {record.trust === 'auto' ? 'Auto-book' : 'Confirm before booking'}
                               {record.validUntil && (
-                                <> &middot; until {new Date(record.validUntil).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}</>
+                                <> &middot; until {formatValidUntil(record.validUntil)}</>
                               )}
                             </p>
                           </div>

--- a/server/src/lib/availabilityValidate.js
+++ b/server/src/lib/availabilityValidate.js
@@ -9,10 +9,40 @@ function validWindow(w) {
     HHMM.test(w.startTime || '') && HHMM.test(w.endTime || '') && w.startTime < w.endTime;
 }
 
+const ISO_DATE = /^(\d{4})-(\d{2})-(\d{2})$/;
+const ISO_DATETIME_TZ =
+  /^(\d{4})-(\d{2})-(\d{2})T([01]\d|2[0-3]):[0-5]\d(:[0-5]\d(\.\d+)?)?(Z|[+-]([01]\d|2[0-3]):[0-5]\d)$/;
+
+// Last calendar day of month `m` (1-12) in year `y`. Date.UTC(y, m, 0) rolls
+// back to the final day of the preceding month, which gets leap years right.
+function daysInMonth(y, m) {
+  return new Date(Date.UTC(y, m, 0)).getUTCDate();
+}
+
+// validUntil must be ISO *and* unambiguous about which instant it names.
+//
+// `new Date()` alone is far too permissive for a field named ISO: it accepts
+// '12/31/2026', 'Dec 31 2026' and even a bare '2026'. Worse, two cases are
+// actively wrong rather than merely sloppy:
+//
+//   - A datetime with no offset ('2026-12-31T00:00:00') is parsed in the
+//     host's local zone, so the same request stores a different instant
+//     depending on which machine served it. Date-only is fine — the spec
+//     reads it as UTC.
+//   - Date silently rolls impossible dates over: '2026-02-31' becomes
+//     2026-03-03, so a typo would set an expiry three days past anything the
+//     caller asked for. The calendar date is therefore checked arithmetically
+//     rather than trusted to the parse.
 function isValidISODateTime(str) {
   if (typeof str !== 'string') return false;
-  const d = new Date(str);
-  return !Number.isNaN(d.getTime());
+  const m = ISO_DATE.exec(str) || ISO_DATETIME_TZ.exec(str);
+  if (!m) return false;
+  const year = Number(m[1]);
+  const month = Number(m[2]);
+  const day = Number(m[3]);
+  if (month < 1 || month > 12) return false;
+  if (day < 1 || day > daysInMonth(year, month)) return false;
+  return !Number.isNaN(new Date(str).getTime());
 }
 
 export function validateAvailability(body) {
@@ -36,7 +66,11 @@ export function validateAvailability(body) {
     }
     if (!TRUST.has(trust)) return { valid: false, error: 'trust must be confirm|auto' };
     if (validUntil !== undefined && !isValidISODateTime(validUntil)) {
-      return { valid: false, error: 'validUntil must be a valid ISO datetime string' };
+      return {
+        valid: false,
+        error:
+          'validUntil must be an ISO date (2026-12-31) or an offset-qualified ISO datetime (2026-12-31T00:00:00Z)',
+      };
     }
     const value = {
       scope: { type: scope.type, value: scope.value },

--- a/server/src/mcp/tools.js
+++ b/server/src/mcp/tools.js
@@ -855,12 +855,25 @@ async function listCommunities() {
 // lexicons/chat/avails/scheduling/availability.json). Does not itself
 // validate that `value` is a well-formed at:// URI — resolveListAvailability
 // does that for the atproto-list path.
+const SCOPE_TYPES = ['atproto-list', 'ca-community'];
+
 function normalizeScope(scope) {
+  // A bare string is unambiguous shorthand — there is only one kind of URI a
+  // caller can pass — so it still defaults.
   if (typeof scope === 'string') {
     return { type: 'atproto-list', value: scope };
   }
   if (scope && typeof scope === 'object' && typeof scope.value === 'string') {
-    return { type: scope.type || 'atproto-list', value: scope.value };
+    // An object that names no type is a caller bug, not shorthand: defaulting
+    // it silently sent a mistyped ca-community scope down the list path, where
+    // it failed later with an unrelated error about the URI shape.
+    if (scope.type === undefined) {
+      throw new Error(`scope.type is required when scope is an object: one of ${SCOPE_TYPES.join(', ')}`);
+    }
+    if (!SCOPE_TYPES.includes(scope.type)) {
+      throw new Error(`Unknown scope.type "${scope.type}": expected one of ${SCOPE_TYPES.join(', ')}`);
+    }
+    return { type: scope.type, value: scope.value };
   }
   throw new Error(
     'scope is required: either an at://<did>/app.bsky.graph.list/<rkey> URI string, or { type, value }'

--- a/server/src/routes/availability.js
+++ b/server/src/routes/availability.js
@@ -1,10 +1,27 @@
 import { Router } from 'express';
+import { createHash } from 'node:crypto';
 import { requireAuth } from '../middleware/auth.js';
 import { validateAvailability } from '../lib/availabilityValidate.js';
 
 const router = Router();
 
 const AVAILABILITY_COLLECTION = 'chat.avails.scheduling.availability';
+
+// One record per scope, enforced structurally rather than by checking first.
+//
+// The rkey is derived from the scope, so re-publishing the same scope is a
+// putRecord to the same key — an overwrite. The previous list-then-create was
+// not atomic: two concurrent POSTs could both observe "no prior" and both
+// createRecord, leaving the user with two public records for one scope. There
+// is no cross-record transaction in ATProto to fix that with, but a
+// deterministic key removes the need for one — the duplicate becomes
+// unrepresentable instead of merely unlikely.
+//
+// 24 hex chars (96 bits) is far inside the rkey charset ([A-Za-z0-9.-_~],
+// 1-512) and collision-safe at this scale.
+export function rkeyForScope(scope) {
+  return createHash('sha256').update(`${scope.type}\n${scope.value}`).digest('hex').slice(0, 24);
+}
 
 // Fetch with timeout — prevents hanging on slow PDS responses
 function fetchWithTimeout(url, options = {}, timeoutMs = 10000) {
@@ -74,44 +91,65 @@ router.post('/', requireAuth, validateAvailabilityBody, async (req, res, next) =
     const did = req.userDid;
     const pds = await resolvePds(did);
 
+    const scope = req.validatedBody.scope;
+    const rkey = rkeyForScope(scope);
+
     const existing = await listAvailabilityRecords(did, pds);
-    const prior = existing.find((r) => r.value?.scope?.value === req.validatedBody.scope.value);
+    const sameScope = existing.filter((r) => r.value?.scope?.value === scope.value);
+    const prior = sameScope.find((r) => r.uri.split('/').pop() === rkey);
+    // Records written before the deterministic scheme carry a TID rkey, as can
+    // a duplicate the old non-atomic path produced. Either would linger as a
+    // second public record for this scope, so they're swept below.
+    const stale = sameScope.filter((r) => r.uri.split('/').pop() !== rkey);
 
     const now = new Date().toISOString();
     // The lexicon requires createdAt (validateAvailability doesn't produce it —
     // same division of labor as polls.js, which stamps createdAt in the route).
+    // Carry it across a legacy record too, so migrating a key doesn't reset the
+    // user's original publish date.
+    const priorCreatedAt = prior?.value?.createdAt || stale[0]?.value?.createdAt;
     const record = {
       $type: AVAILABILITY_COLLECTION,
       ...req.validatedBody,
-      createdAt: prior?.value?.createdAt || now,
-      ...(prior ? { updatedAt: now } : {}),
+      createdAt: priorCreatedAt || now,
+      ...(priorCreatedAt ? { updatedAt: now } : {}),
     };
 
-    let result;
-    if (prior) {
-      const rkey = prior.uri.split('/').pop();
-      result = await xrpcCall(req.oauthSession, 'com.atproto.repo.putRecord', {
-        repo: did,
-        collection: AVAILABILITY_COLLECTION,
-        rkey,
-        record,
-        swapRecord: prior.cid,
-      });
-    } else {
-      result = await xrpcCall(req.oauthSession, 'com.atproto.repo.createRecord', {
-        repo: did,
-        collection: AVAILABILITY_COLLECTION,
-        record,
-      });
+    const result = await xrpcCall(req.oauthSession, 'com.atproto.repo.putRecord', {
+      repo: did,
+      collection: AVAILABILITY_COLLECTION,
+      rkey,
+      record,
+      // CAS only when overwriting the deterministic key, so a concurrent edit
+      // fails loudly rather than silently losing the other write.
+      ...(prior ? { swapRecord: prior.cid } : {}),
+    });
+
+    // Best-effort, and deliberately after the write: the new record landing is
+    // the outcome that matters, so a failed cleanup must not fail the publish
+    // or roll it back (same reasoning as the Google Calendar path in polls.js).
+    // The caller is told what's left over rather than it failing silently.
+    let staleRemaining = 0;
+    for (const r of stale) {
+      try {
+        await xrpcCall(req.oauthSession, 'com.atproto.repo.deleteRecord', {
+          repo: did,
+          collection: AVAILABILITY_COLLECTION,
+          rkey: r.uri.split('/').pop(),
+        });
+      } catch (e) {
+        staleRemaining += 1;
+        console.error(`[availability] Failed to sweep stale record ${r.uri}:`, e.message);
+      }
     }
 
-    const rkey = result.uri.split('/').pop();
-    res.status(prior ? 200 : 201).json({
+    res.status(priorCreatedAt ? 200 : 201).json({
       uri: result.uri,
       cid: result.cid,
       rkey,
       did,
-      replaced: Boolean(prior),
+      replaced: Boolean(priorCreatedAt),
+      ...(staleRemaining > 0 && { staleRemaining }),
     });
   } catch (err) {
     next(err);

--- a/server/test/availability.route.test.js
+++ b/server/test/availability.route.test.js
@@ -31,9 +31,15 @@ mock.module('../src/lib/sessionStore.js', {
 
 // Track XRPC calls made through the mocked OAuth session
 let lastXrpcCall = null;
+// Every XRPC call in order — the legacy sweep (#106) makes more than one write
+// per publish, which lastXrpcCall alone can't see.
+let xrpcCalls = [];
+// Lets one test drive the sweep's failure path.
+let failDeletes = false;
 const mockFetchHandler = async (pathname, opts) => {
   const body = JSON.parse(opts.body);
   lastXrpcCall = { pathname, body };
+  xrpcCalls.push({ method: pathname.replace('/xrpc/', ''), body });
   const method = pathname.replace('/xrpc/', '');
   if (method === 'com.atproto.repo.createRecord') {
     return {
@@ -50,6 +56,9 @@ const mockFetchHandler = async (pathname, opts) => {
     };
   }
   // deleteRecord
+  if (failDeletes) {
+    return { ok: false, status: 500, json: async () => ({}), text: async () => 'delete boom' };
+  }
   return { ok: true, json: async () => ({}), text: async () => 'ok' };
 };
 
@@ -117,6 +126,8 @@ describe('POST /api/availability', () => {
   beforeEach(() => {
     mockSessions.clear();
     lastXrpcCall = null;
+    xrpcCalls = [];
+    failDeletes = false;
     mockListRecordsData = { records: [] };
     mockSessions.set('creator-session', {
       did,
@@ -151,9 +162,12 @@ describe('POST /api/availability', () => {
     const res = await request(app, 'POST', '/api/availability', validBody, sessionCookie);
     assert.equal(res.status, 201);
     assert.ok(lastXrpcCall);
-    assert.equal(lastXrpcCall.pathname, '/xrpc/com.atproto.repo.createRecord');
+    // putRecord at a scope-derived rkey, not createRecord — see #106: a create
+    // is the call that races into duplicates.
+    assert.equal(lastXrpcCall.pathname, '/xrpc/com.atproto.repo.putRecord');
     assert.equal(lastXrpcCall.body.repo, did);
     assert.equal(lastXrpcCall.body.collection, AVAILABILITY_COLLECTION);
+    assert.ok(lastXrpcCall.body.rkey);
     assert.equal(lastXrpcCall.body.record.$type, AVAILABILITY_COLLECTION);
     assert.equal(lastXrpcCall.body.record.trust, 'confirm');
     assert.deepStrictEqual(lastXrpcCall.body.record.scope, validBody.scope);
@@ -185,16 +199,93 @@ describe('POST /api/availability', () => {
     const app = createApp();
     const res = await request(app, 'POST', '/api/availability', validBody, sessionCookie);
     assert.equal(res.status, 200);
-    assert.ok(lastXrpcCall);
-    assert.equal(lastXrpcCall.pathname, '/xrpc/com.atproto.repo.putRecord');
-    assert.equal(lastXrpcCall.body.repo, did);
-    assert.equal(lastXrpcCall.body.collection, AVAILABILITY_COLLECTION);
-    assert.equal(lastXrpcCall.body.rkey, 'oldrkey999');
-    assert.equal(lastXrpcCall.body.swapRecord, 'cid-old');
-    assert.equal(lastXrpcCall.body.record.trust, 'confirm'); // new value wins
-    assert.equal(lastXrpcCall.body.record.createdAt, '2026-01-01T00:00:00.000Z'); // preserved
-    assert.ok(lastXrpcCall.body.record.updatedAt);
+
+    // The rkey now comes from the scope, not from whatever key the prior record
+    // happened to have (#106) — so the legacy TID-keyed record is rewritten at
+    // the deterministic key and the old one swept, rather than reused in place.
+    const put = xrpcCalls.find((c) => c.method === 'com.atproto.repo.putRecord');
+    assert.ok(put, 'must putRecord');
+    assert.equal(put.body.repo, did);
+    assert.equal(put.body.collection, AVAILABILITY_COLLECTION);
+    assert.notEqual(put.body.rkey, 'oldrkey999');
+    assert.equal(put.body.record.trust, 'confirm'); // new value wins
+    assert.equal(put.body.record.createdAt, '2026-01-01T00:00:00.000Z'); // carried across the key change
+    assert.ok(put.body.record.updatedAt);
+
+    const del = xrpcCalls.find((c) => c.method === 'com.atproto.repo.deleteRecord');
+    assert.ok(del, 'the legacy record must be swept, not left as a second public record');
+    assert.equal(del.body.rkey, 'oldrkey999');
+
     assert.equal(res.body.replaced, true);
+    assert.equal(res.body.staleRemaining, undefined);
+  });
+
+  it('derives the rkey from the scope so a re-publish overwrites rather than racing (#106)', async () => {
+    const app = createApp();
+    const res = await request(app, 'POST', '/api/availability', validBody, sessionCookie);
+    assert.equal(res.status, 201);
+
+    // createRecord is what races — two concurrent POSTs could both create.
+    // putRecord at a scope-derived key makes a duplicate unrepresentable.
+    assert.equal(
+      xrpcCalls.some((c) => c.method === 'com.atproto.repo.createRecord'),
+      false,
+      'must never createRecord — that is the racing call'
+    );
+    const put = xrpcCalls.find((c) => c.method === 'com.atproto.repo.putRecord');
+    assert.ok(put);
+    assert.match(put.body.rkey, /^[A-Za-z0-9._~-]{1,512}$/, 'valid ATProto rkey syntax');
+    assert.equal(put.body.swapRecord, undefined, 'no CAS when there is no prior record at that key');
+
+    // Same scope again -> same key. This is the property that kills the race.
+    const firstRkey = put.body.rkey;
+    xrpcCalls = [];
+    await request(app, 'POST', '/api/availability', validBody, sessionCookie);
+    const second = xrpcCalls.find((c) => c.method === 'com.atproto.repo.putRecord');
+    assert.equal(second.body.rkey, firstRkey);
+  });
+
+  it('gives a different scope a different rkey', async () => {
+    const app = createApp();
+    await request(app, 'POST', '/api/availability', validBody, sessionCookie);
+    const a = xrpcCalls.find((c) => c.method === 'com.atproto.repo.putRecord').body.rkey;
+
+    xrpcCalls = [];
+    await request(app, 'POST', '/api/availability', {
+      ...validBody,
+      scope: { type: 'atproto-list', value: 'at://did:plc:owner/app.bsky.graph.list/other' },
+    }, sessionCookie);
+    const b = xrpcCalls.find((c) => c.method === 'com.atproto.repo.putRecord').body.rkey;
+
+    assert.notEqual(a, b, 'two scopes must not collide onto one record');
+  });
+
+  it('reports stale records it could not sweep instead of failing silently', async () => {
+    mockListRecordsData = {
+      records: [
+        {
+          uri: `at://${did}/${AVAILABILITY_COLLECTION}/legacytid01`,
+          cid: 'cid-legacy',
+          value: {
+            $type: AVAILABILITY_COLLECTION,
+            scope: validBody.scope,
+            pattern: { weekly: [{ day: 3, startTime: '10:00', endTime: '11:00' }] },
+            timezone: 'UTC',
+            trust: 'auto',
+            createdAt: '2026-01-01T00:00:00.000Z',
+          },
+        },
+      ],
+    };
+    failDeletes = true;
+    const app = createApp();
+    const res = await request(app, 'POST', '/api/availability', validBody, sessionCookie);
+
+    // The publish still succeeds — the new record landing is the outcome that
+    // matters, and a failed cleanup must not roll it back.
+    assert.equal(res.status, 200);
+    assert.ok(xrpcCalls.find((c) => c.method === 'com.atproto.repo.putRecord'));
+    assert.equal(res.body.staleRemaining, 1);
   });
 });
 
@@ -202,6 +293,8 @@ describe('GET /api/availability/mine', () => {
   beforeEach(() => {
     mockSessions.clear();
     lastXrpcCall = null;
+    xrpcCalls = [];
+    failDeletes = false;
     mockSessions.set('creator-session', {
       did,
       handle: 'caller.test',
@@ -244,6 +337,8 @@ describe('DELETE /api/availability/:rkey', () => {
   beforeEach(() => {
     mockSessions.clear();
     lastXrpcCall = null;
+    xrpcCalls = [];
+    failDeletes = false;
     mockSessions.set('creator-session', {
       did,
       handle: 'caller.test',

--- a/server/test/availabilityValidate.test.js
+++ b/server/test/availabilityValidate.test.js
@@ -135,3 +135,64 @@ test('rejects timezone exceeding 64 chars', () => {
   assert.equal(r.valid, false);
   assert.match(r.error, /64/);
 });
+
+// --- #106 fast-follows: edge cases the PR #104 reviews flagged as untested ---
+
+function baseBody(extra = {}) {
+  return {
+    scope: { type: 'atproto-list', value: 'at://did:plc:x/app.bsky.graph.list/abc' },
+    pattern: { weekly: [{ day: 2, startTime: '14:00', endTime: '18:00' }] },
+    timezone: 'Europe/Berlin',
+    trust: 'confirm',
+    ...extra,
+  };
+}
+
+test('rejects a window whose startTime equals its endTime', () => {
+  const r = validateAvailability(baseBody({
+    pattern: { weekly: [{ day: 2, startTime: '14:00', endTime: '14:00' }] },
+  }));
+  assert.equal(r.valid, false);
+});
+
+test('rejects a non-string validUntil', () => {
+  for (const bad of [123, {}, [], true, null]) {
+    const r = validateAvailability(baseBody({ validUntil: bad }));
+    assert.equal(r.valid, false, `expected ${JSON.stringify(bad)} to be rejected`);
+  }
+});
+
+test('accepts a date-only validUntil — unambiguously UTC per the JS spec', () => {
+  assert.equal(validateAvailability(baseBody({ validUntil: '2026-12-31' })).valid, true);
+});
+
+test('accepts offset-qualified ISO datetimes', () => {
+  for (const good of ['2026-12-31T00:00:00Z', '2026-09-11T00:00:00.000Z', '2026-12-31T01:00:00+05:30']) {
+    assert.equal(validateAvailability(baseBody({ validUntil: good })).valid, true, `expected ${good} accepted`);
+  }
+});
+
+test('rejects a datetime with no offset — it would mean a different instant per host', () => {
+  // new Date('2026-12-31T00:00:00') is parsed in the SERVER's local zone, so
+  // the stored instant would depend on which machine handled the request.
+  assert.equal(validateAvailability(baseBody({ validUntil: '2026-12-31T00:00:00' })).valid, false);
+});
+
+test('rejects non-ISO formats that Date happens to parse', () => {
+  // The function is named isValidISODateTime and its error says "ISO", but it
+  // accepted anything Date could parse — including a bare year.
+  for (const bad of ['12/31/2026', 'Dec 31 2026', '2026', '2026-13-01', '2026-12-32']) {
+    assert.equal(validateAvailability(baseBody({ validUntil: bad })).valid, false, `expected ${bad} rejected`);
+  }
+});
+
+test('rejects an impossible calendar date instead of silently rolling it over', () => {
+  // new Date('2026-02-31') yields 2026-03-03 — a user typing Feb 31 would get
+  // an expiry three days later than anything they asked for.
+  assert.equal(validateAvailability(baseBody({ validUntil: '2026-02-31' })).valid, false);
+});
+
+test('handles leap years when validating the calendar date', () => {
+  assert.equal(validateAvailability(baseBody({ validUntil: '2028-02-29' })).valid, true, '2028 is a leap year');
+  assert.equal(validateAvailability(baseBody({ validUntil: '2026-02-29' })).valid, false, '2026 is not');
+});

--- a/server/test/scheduleCall.test.js
+++ b/server/test/scheduleCall.test.js
@@ -197,6 +197,60 @@ describe('schedule_call', () => {
     assert.deepEqual(fetchCalls, []);
   });
 
+  it('(f) an object scope with no type is rejected — the tool schema declares type required', async () => {
+    resetHooks();
+    // TOOL_DEFINITIONS says required: ['type','value'] for the object form, so
+    // defaulting a missing type silently contradicted the published contract:
+    // a mistyped ca-community scope went down the list path and failed later
+    // with an unrelated error about the URI shape.
+    await assert.rejects(
+      () => callTool('schedule_call', {
+        scope: { value: LIST_URI },
+        durationMinutes: 60,
+        window: WINDOW,
+        title: 'Weekly sync',
+      }, null),
+      /scope\.type is required/
+    );
+    assert.deepEqual(fetchCalls, []);
+  });
+
+  it('(g) an unknown scope.type is rejected rather than silently treated as a list', async () => {
+    resetHooks();
+    await assert.rejects(
+      () => callTool('schedule_call', {
+        scope: { type: 'atproto-lst', value: LIST_URI }, // typo
+        durationMinutes: 60,
+        window: WINDOW,
+        title: 'Weekly sync',
+      }, null),
+      /Unknown scope\.type "atproto-lst"/
+    );
+    assert.deepEqual(fetchCalls, []);
+  });
+
+  it('(h) a bare list-URI string is still accepted as Phase 1 shorthand', async () => {
+    resetHooks();
+    // Guards the other side of (f): a string is unambiguous — there is only one
+    // kind of URI a caller can pass — so it must keep defaulting to a list.
+    resolveListAvailabilityImpl = async (listUri) => {
+      assert.equal(listUri, LIST_URI);
+      return [member('did:plc:alice', 'auto'), member('did:plc:bob', 'auto')];
+    };
+    bestCallSlotsImpl = () => [
+      { slot: '2026-07-21T14:00', participants: ['did:plc:alice', 'did:plc:bob'], count: 2 },
+    ];
+
+    const result = JSON.parse(await callTool('schedule_call', {
+      scope: LIST_URI,
+      durationMinutes: 60,
+      window: WINDOW,
+      title: 'Weekly sync',
+    }, null));
+
+    assert.equal(result.booked, true);
+  });
+
   it('(e) a ca-community scope is rejected with a clear Phase 1 error, before touching resolveListAvailability', async () => {
     resetHooks();
     // resolveListAvailabilityImpl left as the "should not be called" throw.


### PR DESCRIPTION
Addresses **5 of the 6** fast-follows in #106.

## Validator strictness (item 1)

`isValidISODateTime` is named for ISO and its error message promises ISO, but it accepted anything `Date` could parse. Probing it turned up more than the issue described — and three cases are actively wrong, not merely lax:

| input | old behaviour |
|---|---|
| `2026-12-31T00:00:00` (no offset) | parsed in the **host's local zone** |
| `2026-02-31` | silently became **`2026-03-03`** |
| `12/31/2026`, `Dec 31 2026`, `2026` | all accepted |
| `2026-12-31` (date-only) | UTC midnight — actually fine, the spec reads date-only as UTC |

The no-offset case means **the same request stores a different instant depending on which machine served it**. The rollover means a user typing Feb 31 gets an expiry three days past anything they asked for.

Now requires a date-only ISO string *or* an offset-qualified ISO datetime, and validates the calendar date arithmetically instead of trusting the parse (`Date.UTC(y, m, 0)` handles leap years).

**Existing records are unaffected** — both the UI and the 8-week default emit `toISOString()`, which is always offset-qualified. Explicitly covered by a test.

The issue also asked for edge tests on `startTime == endTime` and a non-string `validUntil`. Both **passed unchanged**, confirming the issue's read that the code was correct and only the coverage was missing.

## One-record-per-scope race (item 2)

Artem's call: no third-party records yet, so the rkey scheme is free to change.

The rkey is now `sha256(type\nvalue)` (24 hex chars), so re-publishing a scope is a `putRecord` to the same key. **`createRecord` is never called — that's the call that races.** Two concurrent POSTs now collide onto one key and one wins, instead of both creating. The duplicate becomes *unrepresentable* rather than merely unlikely, which is the only real fix available given ATProto has no cross-record transaction.

`swapRecord` is sent only when a record already exists at that key, so a concurrent edit fails loudly rather than silently losing the other write.

**Legacy sweep.** Records written before this carry a TID rkey — as would any duplicate the old path already produced — and would otherwise linger as a second public record for the same scope. They're deleted after the write: best-effort, and deliberately after, because the new record landing is the outcome that matters and a failed cleanup must not roll the publish back (same reasoning as the Google Calendar path in `polls.js`). Leftovers surface as `staleRemaining` instead of failing silently. `createdAt` carries across the key change, so migrating doesn't reset the original publish date.

**Why a sweep rather than a "please delete by hand" note:** the premise is only partly verifiable. Exactly one record exists (Artem's own smoke record) across the Standing Avails Test list and its owner — but that's 5 DIDs, not the network. `/availability` has been public since 10:31 and there's no firehose index to enumerate against, so the migration is self-healing rather than assumed away.

Pagination (the other half of item 2) is still `limit=100` with no cursor — implausible at one record per scope, and now bounded by construction.

## normalizeScope (item 6)

Not a design preference — the implementation contradicted its own published schema. `TOOL_DEFINITIONS` declares:

```js
required: ['type', 'value'],
```

...while `normalizeScope` did `type: scope.type || 'atproto-list'`. So a mistyped `ca-community` scope silently went down the list path and failed later with an unrelated error about the URI shape. Now errors on a missing type and on an unknown one. The bare-string shorthand still defaults, since a string is unambiguous — guarded by a test so the two don't drift.

## UI validUntil display (item 3)

The published-record "until \<date\>" line formatted a UTC-midnight instant with browser-local getters, so a UTC-negative user saw the previous day. `isoToDateInputValue`'s comment already spells out this exact hazard for the edit path — *"would read back one day earlier for every UTC-negative timezone"* — the read-only display just didn't follow its own advice. Pinned to UTC via `timeZone: 'UTC'`, keeping locale-aware formatting.

`handleCancelEdit` now clears `cleanupWarning` too.

## Verification

113/113 passing; client builds. RED was verified for every fix — the scope tests were run against the original `tools.js` to confirm they actually catch the default (they did: (f) and (g) failed, the string-shorthand guard passed).

Test-harness note: the existing "replaces the prior record" test asserted the prior record's *own* rkey was reused — that behaviour is what changed, so it now asserts the deterministic key plus the sweep. `lastXrpcCall` can't see a multi-write publish, so an `xrpcCalls` array was added alongside it.

## Still open on #106

- **DST spring-forward** (item 4). Real, narrow (transition date + DST zone + straddling window), and a proper fix means comparing offsets across the transition rather than trusting Luxon's `isValid`.
- **`schedule_call` rate limit** (item 5). Genuinely a policy question: what limit, keyed on what? It's unauthenticated and fans out to every member's PDS — the "Software for Citizens" list is 22 members, so one call is ~44 third-party requests.
