### PR TITLE
fix(mcp): rate-limit the JSON-RPC endpoint (#106)

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -80,6 +80,19 @@ const availabilityCreateLimiter = rateLimit({
   message: { error: 'Too many availability records created. Try again later.' },
 });
 
+// The MCP tools are unauthenticated by design (they read public PDS records),
+// but schedule_call fans out to plc.directory plus every member's PDS — a
+// 22-member list is ~44 third-party requests for one call. That makes /mcp the
+// largest amplification surface here, so it gets the same treatment as every
+// other public entry point. 60/hr matches responseLimiter, the most permissive
+// existing tier: generous for real agent use (a session is 10-20 calls) while
+// capping fan-out at roughly 1.3k third-party requests/hr from any one IP.
+const mcpLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 60,
+  message: { error: 'Too many MCP requests. Try again later.' },
+});
+
 // Auth routes (login, callback, session, logout, client-metadata, jwks)
 app.use('/api/auth/login', authLimiter);
 app.use('/api/auth', authRoutes);
@@ -108,8 +121,10 @@ app.use('/', mcpOauthRoutes);
 // MCP OAuth routes (register, authorize, callback, token)
 app.use('/mcp', mcpOauthRoutes);
 
-// MCP JSON-RPC endpoint
-app.post('/mcp', handleMcp);
+// MCP JSON-RPC endpoint. Rate-limited here rather than on the whole /mcp
+// prefix so the multi-step OAuth flow mounted above doesn't spend the tool
+// budget. DELETE is session teardown, not a fan-out surface, so it's exempt.
+app.post('/mcp', mcpLimiter, handleMcp);
 app.delete('/mcp', handleMcpDelete);
 
 // Admin: clear all sessions (requires SESSION_SECRET as query param)


### PR DESCRIPTION
Last of the #106 fast-follows.

`/mcp` was the **only public entry point without a limiter**. `index.js` already had four:

| limiter | max/hr | applied to |
|---|---|---|
| `authLimiter` | 20 | `/api/auth/login` |
| `pollCreateLimiter` | 30 | `POST /api/polls` |
| `availabilityCreateLimiter` | 30 | `POST /api/availability` |
| `responseLimiter` | 60 | `POST /api/polls/:did/:rkey/responses` |

So this wasn't a policy to invent — just an endpoint that missed an established convention.

## Why it matters here

The MCP tools are unauthenticated **by design** (they read public PDS records), which is fine on its own. But `schedule_call` fans out to `plc.directory` plus every member's PDS — the "Software for Citizens" list is 22 members, so **one call is ~44 third-party requests**. That makes `/mcp` the largest amplification surface in the app: the cost of abuse lands on other people's infrastructure, not just ours.

## The numbers

**60/hr per IP**, matching `responseLimiter` (the most permissive existing tier). Generous for real agent use — a working session is 10–20 calls — while capping fan-out at roughly **1.3k third-party requests/hr** from any single IP.

## Scope

Applied to `app.post('/mcp')` specifically, **not** the `/mcp` prefix. The OAuth flow is mounted at `app.use('/mcp', mcpOauthRoutes)` above it, and a multi-step consent flow shouldn't spend the tool budget. `DELETE /mcp` is session teardown, not a fan-out surface, so it's exempt.

## No test

Deliberate. This is declarative config over a well-tested library, consistent with the four existing limiters — none of which are tested either. A test here would fire 61 requests to assert that `express-rate-limit` counts to 60.

113/113 passing.

## DST (#106 item 4) — closing as accepted

Not fixed, deliberately. `availabilityOverlap.js:100-108` **already documents it** — the reviews flagged a known, consciously-accepted gap rather than discovering an unknown.

For it to bite, all of these must hold at once: a member publishes availability landing in the 1-hour spring-forward gap (02:00–03:00 local), on the ~one transition day per year, in a DST zone. Nobody publishes 2am availability for group calls.

The fix means adding offset-comparison logic to the most delicate code in the system to protect a case that essentially cannot occur — and it would force a product question with no clean answer: what *should* "I'm free 02:00–03:00" mean on a day when 02:00–03:00 doesn't exist? Skip the window, shift it, or clamp it? Inventing an answer for a case nobody hits is how timezone code gets worse. The honest comment in the code is the better artifact.
