### PR TITLE
fix(auth): lazy-restore the OAuth session in requireAuth

### DIFF
--- a/server/src/middleware/auth.js
+++ b/server/src/middleware/auth.js
@@ -1,6 +1,7 @@
 import { getSession, sessions } from '../lib/sessionStore.js';
+import { getClient } from '../routes/auth.js';
 
-export function requireAuth(req, res, next) {
+export async function requireAuth(req, res, next) {
   const sessionId = req.cookies?.avails_session;
   if (!sessionId) {
     console.log('requireAuth: no avails_session cookie. Cookies:', Object.keys(req.cookies || {}));
@@ -11,6 +12,31 @@ export function requireAuth(req, res, next) {
   if (!session) {
     console.log(`requireAuth: session not found. ID prefix: ${sessionId.substring(0, 8)}... Store has ${sessions.size} sessions.`);
     return res.status(401).json({ error: 'Session expired' });
+  }
+
+  // The startup restore fetches client-metadata.json from our own PUBLIC URL,
+  // which Railway's edge doesn't route to until the deploy is healthy — so on
+  // every redeploy it fails with invalid_client_metadata, sets oauthSession to
+  // null, and logs "will retry on demand". Nothing here retried it, so the next
+  // authenticated write dereferenced null and threw "Cannot read properties of
+  // null (reading 'fetchHandler')" at a user whose cookie still looked valid.
+  //
+  // Deferring is sound — by the time a request arrives the deploy IS healthy and
+  // the URL resolves, so restoring here succeeds where startup couldn't. It just
+  // needed doing. Mirrors findOauthSessionByDid in routes/responses.js and the
+  // restore in mcp/handler.js, which already do exactly this.
+  if (!session.oauthSession && session.did) {
+    try {
+      const client = await getClient();
+      session.oauthSession = await client.restore(session.did);
+      console.log(`Lazy-restored OAuth session for ${session.did}`);
+    } catch (err) {
+      console.warn(`Lazy restore failed for ${session.did}:`, err.message);
+      // Fail as "signed out" rather than passing null downstream. A grant we
+      // can't restore isn't usable for writes, and telling the user to sign in
+      // again actually repairs their state — a TypeError doesn't.
+      return res.status(401).json({ error: 'Session expired. Please sign in again.' });
+    }
   }
 
   req.userDid = session.did;

--- a/server/test/requireAuth.test.js
+++ b/server/test/requireAuth.test.js
@@ -1,0 +1,123 @@
+/**
+ * Tests for requireAuth's lazy OAuth-session restore.
+ *
+ * The startup restore fetches client-metadata.json from the server's own PUBLIC
+ * URL, which Railway's edge doesn't route to until the deploy is healthy — so
+ * every redeploy leaves sessions with `oauthSession: null`, logged as "will
+ * retry on demand". Nothing retried it, so the next authenticated write hit
+ * `oauthSession.fetchHandler` on null and threw at the user (2026-07-17, real
+ * report: "Cannot read properties of null (reading 'fetchHandler')").
+ *
+ * Requires --experimental-test-module-mocks.
+ */
+
+import { describe, it, beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+const DID = 'did:plc:caller';
+
+let restoreImpl;
+mock.module('../src/routes/auth.js', {
+  namedExports: {
+    getClient: async () => ({ restore: (did) => restoreImpl(did) }),
+  },
+});
+
+const mockSessions = new Map();
+mock.module('../src/lib/sessionStore.js', {
+  namedExports: {
+    sessions: mockSessions,
+    getSession: (id) => mockSessions.get(id),
+  },
+});
+
+const { requireAuth } = await import('../src/middleware/auth.js');
+
+function mkRes() {
+  const res = { statusCode: null, body: null };
+  res.status = (c) => { res.statusCode = c; return res; };
+  res.json = (b) => { res.body = b; return res; };
+  return res;
+}
+
+function mkReq(cookie) {
+  return { cookies: cookie ? { avails_session: cookie } : {} };
+}
+
+describe('requireAuth', () => {
+  beforeEach(() => {
+    mockSessions.clear();
+    restoreImpl = async () => {
+      throw new Error('restore should not be called in this test');
+    };
+  });
+
+  it('401s with no cookie', async () => {
+    const res = mkRes();
+    let nexted = false;
+    await requireAuth(mkReq(null), res, () => { nexted = true; });
+    assert.equal(res.statusCode, 401);
+    assert.equal(nexted, false);
+  });
+
+  it('401s when the session id is unknown', async () => {
+    const res = mkRes();
+    let nexted = false;
+    await requireAuth(mkReq('nope'), res, () => { nexted = true; });
+    assert.equal(res.statusCode, 401);
+    assert.equal(nexted, false);
+  });
+
+  it('passes a live session straight through without restoring', async () => {
+    const live = { fetchHandler: async () => ({ ok: true }) };
+    mockSessions.set('sid', { did: DID, handle: 'caller.test', oauthSession: live });
+
+    const req = mkReq('sid');
+    const res = mkRes();
+    let nexted = false;
+    await requireAuth(req, res, () => { nexted = true; });
+
+    assert.equal(nexted, true);
+    assert.equal(req.userDid, DID);
+    assert.equal(req.oauthSession, live);
+  });
+
+  it('lazy-restores a session deferred by a failed startup restore', async () => {
+    // This is the real-world case: cookie valid, oauthSession null because the
+    // deploy-time restore couldn't reach its own metadata URL yet.
+    const restored = { fetchHandler: async () => ({ ok: true }) };
+    let restoreCalledWith = null;
+    restoreImpl = async (did) => { restoreCalledWith = did; return restored; };
+    mockSessions.set('sid', { did: DID, handle: 'caller.test', oauthSession: null });
+
+    const req = mkReq('sid');
+    const res = mkRes();
+    let nexted = false;
+    await requireAuth(req, res, () => { nexted = true; });
+
+    assert.equal(restoreCalledWith, DID);
+    assert.equal(nexted, true);
+    assert.equal(req.oauthSession, restored, 'the write path must receive a live session');
+    assert.equal(
+      mockSessions.get('sid').oauthSession,
+      restored,
+      'the restored session must be cached back, not re-restored on every request'
+    );
+  });
+
+  it('401s instead of passing null downstream when the restore fails', async () => {
+    // Before the fix this fell through with oauthSession: null and the route
+    // threw "Cannot read properties of null (reading 'fetchHandler')".
+    restoreImpl = async () => { throw new Error('invalid_client_metadata'); };
+    mockSessions.set('sid', { did: DID, handle: 'caller.test', oauthSession: null });
+
+    const req = mkReq('sid');
+    const res = mkRes();
+    let nexted = false;
+    await requireAuth(req, res, () => { nexted = true; });
+
+    assert.equal(nexted, false, 'must not hand a null oauthSession to the route');
+    assert.equal(res.statusCode, 401);
+    assert.match(res.body.error, /sign in again/i);
+  });
+});


### PR DESCRIPTION
Reported from production: editing standing availability failed with **"Cannot read properties of null (reading 'fetchHandler')"**.

## Root cause

Railway logs, on every redeploy:

```
Failed to restore OAuth session for did:plc:7t3... (will retry on demand):
  OAuth "invalid_client_metadata" error: Unable to obtain client metadata for
  "https://avails.zhgnv.com/api/auth/client-metadata-v4.json"
1 sessions deferred — will restore on demand
```

The startup restore fetches `client-metadata.json` from the server's **own public URL**. `app.listen()` has run — satisfying the constraint documented in CLAUDE.md — but Railway's edge doesn't route to the container until the deploy is healthy. So the self-fetch fails, `oauthSession` is set to `null`, and it logs *"will retry on demand"*.

**Nothing retried it.** `requireAuth` assigned that null straight to `req.oauthSession` and called `next()`, so the first `xrpcCall` dereferenced it. The cookie stays valid, so the user looks signed in right up until a write throws a TypeError at them.

That URL serves 200 from outside — this is purely a boot race, not a broken route or a bad grant.

## The fix

The deferral is *sound*: by the time a request arrives, the deploy is healthy and the URL resolves — so restoring at request time succeeds where startup couldn't. It just needed doing.

And the codebase **already does exactly this in two other places**:

- `routes/responses.js:20-41` — `findOauthSessionByDid`, commented *"If the session exists but the live oauthSession is null (failed restore on startup), attempt a lazy restore on the spot."*
- `mcp/handler.js:36` — `oauthSession = await oauthClient.restore(claims.sub)`

`requireAuth` — the path **every authenticated write** takes — was the one that missed it. So this isn't a new pattern, it's applying an existing one where it was skipped.

On restore failure it now **401s "Session expired. Please sign in again."** instead of passing null downstream. A grant we can't restore isn't usable for writes, and telling the user to sign in actually repairs their state — a TypeError doesn't.

## Tests

Five, two of which reproduced the bug:

| | before |
|---|---|
| lazy-restores a deferred session | ✖ — no restore attempted |
| 401s instead of passing null downstream | ✖ — *"must not hand a null oauthSession to the route"* |

The restore test also asserts the session is **cached back**, so it isn't re-restored on every request.

`requireAuth` becomes async. Express doesn't await middleware, but `next()` is called from inside and errors are caught locally, so nothing rejects — the route integration tests that drive it over real HTTP all still pass.

118/118 passing.

## Note

This is why signing out and back in worked around it: `createSession` mints a live `oauthSession` in memory, bypassing the restore path entirely.

Today's five deploys plus a `clear-sessions` made this maximally visible, but it isn't new — any redeploy would defer every session, and the failure has been latent behind long-lived in-memory sessions.
