### PR TITLE
feat(mcp): schedule_call books for an explicit voterDids set (#103)

### DIFF
--- a/server/src/mcp/listMembers.js
+++ b/server/src/mcp/listMembers.js
@@ -42,7 +42,7 @@ async function resolvePds(did) {
 // authority DID, which is the list's owner — a record can only live in its
 // own creator's repo, so this holds without trusting any API response shape.
 // Throws otherwise.
-function parseListUri(listUri) {
+export function parseListUri(listUri) {
   if (typeof listUri !== 'string' || !listUri.startsWith('at://')) {
     throw new Error(`Invalid list URI: ${listUri}`);
   }
@@ -112,28 +112,25 @@ async function resolveMemberRecord(did, listUri) {
 // Public API
 // ---------------------------------------------------------------------------
 
-// Resolves a Bluesky list to the standing-availability records its members
-// have published for that list. Per-member failures (PDS resolution or
-// listRecords) are non-fatal — that member is skipped, not the whole call.
-export async function resolveListAvailability(listUri) {
-  const ownerDid = parseListUri(listUri);
-
-  // getList never returns a list's owner among its items, and Bluesky's UI
-  // refuses to let an owner add themselves — so without this the person
-  // curating a group's list can never be scheduled through it (#110).
-  // Including them unconditionally is safe because opt-in is expressed by the
-  // record's scope, not by list membership: an owner who published no record
-  // for this list is filtered out by resolveMemberRecord and contributes
-  // nothing, so admins curating a roster they aren't part of are unaffected.
-  const dids = [...new Set([ownerDid, ...(await fetchListMemberDids(listUri))])];
+// Resolves the standing-availability records a given set of DIDs have published
+// for a specific list scope. Per-DID failures (PDS resolution / listRecords) are
+// non-fatal — that DID is skipped, not the whole call. DIDs are deduped. The
+// list URI is validated up front so a malformed scope throws loudly rather than
+// resolving to an empty set (which would masquerade as thin coverage).
+//
+// Shared by resolveListAvailability (the whole list) and schedule_call's
+// voter-scoped path (an explicit subset who opted into a proposal) — #103/#119.
+export async function resolveAvailabilityForDids(dids, listUri) {
+  parseListUri(listUri); // throws on a malformed at:// list URI
+  const unique = [...new Set(dids)];
 
   const outcomes = await Promise.allSettled(
-    dids.map((did) => resolveMemberRecord(did, listUri))
+    unique.map((did) => resolveMemberRecord(did, listUri))
   );
 
   const results = [];
   outcomes.forEach((outcome, i) => {
-    const did = dids[i];
+    const did = unique[i];
     if (outcome.status === 'fulfilled') {
       if (outcome.value) results.push({ did, record: outcome.value });
     } else {
@@ -142,4 +139,16 @@ export async function resolveListAvailability(listUri) {
   });
 
   return results;
+}
+
+// Resolves a Bluesky list to the standing-availability records its members have
+// published for that list. Includes the list OWNER, whom getList omits from
+// items and whom Bluesky's UI won't let self-add — so without this the curator
+// of a group's list could never be scheduled through it (#110). Safe because
+// opt-in is the record's scope, not list membership: an owner who published no
+// record for this list is filtered out and contributes nothing.
+export async function resolveListAvailability(listUri) {
+  const ownerDid = parseListUri(listUri);
+  const dids = [ownerDid, ...(await fetchListMemberDids(listUri))];
+  return resolveAvailabilityForDids(dids, listUri);
 }

--- a/server/src/mcp/tools.js
+++ b/server/src/mcp/tools.js
@@ -5,7 +5,7 @@ import { getOpenMeetToken } from '../routes/openmeet.js';
 import { computeBestSlots } from './overlap.js';
 import { sendTelegramMessage } from './telegram.js';
 import { assertMembership } from '../lib/membership.js';
-import { resolveListAvailability } from './listMembers.js';
+import { resolveListAvailability, resolveAvailabilityForDids } from './listMembers.js';
 import { bestCallSlots } from './availabilityOverlap.js';
 
 const POLL_COLLECTION = 'chat.avails.scheduling.poll';
@@ -325,7 +325,7 @@ const TOOL_DEFINITIONS = [
   {
     name: 'schedule_call',
     description:
-      'Book a call directly from a group\'s standing availability — no poll. Resolves the members\' standing-availability records for the given scope, finds the best overlapping slot in the requested window, and books it if coverage is sufficient (at least 2 members with records, and at least 2 free at the chosen slot). Members whose record has trust:auto are auto-booked; trust:confirm members are returned separately and are NOT silently committed. If coverage is too thin, returns a fallback signal instead of booking — it does not create a poll itself. Only atproto-list scopes are supported (ca-community scopes are Phase 3 and are rejected).',
+      'Book a call directly from a group\'s standing availability — no poll. Resolves the members\' standing-availability records for the given scope, finds the best overlapping slot in the requested window, and books it if coverage is sufficient (at least 2 members with records, and at least 2 free at the chosen slot). Members whose record has trust:auto are auto-booked; trust:confirm members are returned separately and are NOT silently committed. If coverage is too thin, returns a fallback signal instead of booking — it does not create a poll itself. Only atproto-list scopes are supported (ca-community scopes are Phase 3 and are rejected). Pass voterDids to book for a specific subset (the people who voted/liked) rather than the whole list.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -363,6 +363,11 @@ const TOOL_DEFINITIONS = [
         title: {
           type: 'string',
           description: 'Call title, used for the calendar invite and confirmation emails.',
+        },
+        voterDids: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Optional. When present, book only for these DIDs (the people who opted into this specific proposal — e.g. the likers of a Bluesky post), instead of the whole list. Their records are still matched to `scope`; a DID that published no availability for this list is a coverage miss. Omit to schedule for the entire list.',
         },
       },
       required: ['scope', 'durationMinutes', 'window', 'title'],
@@ -893,7 +898,7 @@ function parseAtUri(uri) {
 // schedule_call (#103, Task 8, Phase 1): books a call straight from a
 // group's standing availability — no poll. Reading availability records is
 // public (no auth), so this tool does not require authContext.
-async function scheduleCall({ scope, durationMinutes, window, title }) {
+async function scheduleCall({ scope, durationMinutes, window, title, voterDids }) {
   const normalizedScope = normalizeScope(scope);
 
   if (normalizedScope.type === 'ca-community') {
@@ -914,7 +919,24 @@ async function scheduleCall({ scope, durationMinutes, window, title }) {
     throw new Error('title is required');
   }
 
-  const members = await resolveListAvailability(normalizedScope.value);
+  // Optional voter-scoped booking (#103/#119): when the caller supplies an
+  // explicit set of DIDs (the people who opted into a proposal), book for that
+  // subset instead of the whole list. avails does not interpret HOW they voted
+  // (a Bluesky like, an MC vote, a Telegram reaction) — it receives DIDs. Their
+  // records are still matched to `scope`, so a voter who published nothing for
+  // this list is a coverage miss, exactly as an absent list member would be.
+  if (voterDids !== undefined) {
+    if (!Array.isArray(voterDids) || !voterDids.every((d) => typeof d === 'string' && d.startsWith('did:'))) {
+      throw new Error('voterDids must be an array of DID strings');
+    }
+    if (voterDids.length === 0) {
+      throw new Error('voterDids, when provided, must be non-empty');
+    }
+  }
+
+  const members = voterDids
+    ? await resolveAvailabilityForDids(voterDids, normalizedScope.value)
+    : await resolveListAvailability(normalizedScope.value);
   const withRecords = members.length;
 
   // Coverage floor #1: not enough members have published availability at
@@ -1019,6 +1041,10 @@ async function scheduleCall({ scope, durationMinutes, window, title }) {
     coverage: {
       withRecords,
       membersFree: top.count,
+      // When voter-scoped, let the caller see how many of the people who voted
+      // actually had a usable record — so CA can message "3 of 5 voters haven't
+      // published availability" rather than guessing.
+      ...(voterDids ? { voters: voterDids.length, votersWithoutRecords: voterDids.length - withRecords } : {}),
     },
   });
 }

--- a/server/test/listMembers.test.js
+++ b/server/test/listMembers.test.js
@@ -4,7 +4,8 @@ import assert from 'node:assert/strict';
 let fetchImpl;
 globalThis.fetch = (...args) => fetchImpl(...args);
 
-const { resolveListAvailability } = await import('../src/mcp/listMembers.js');
+const { resolveListAvailability, resolveAvailabilityForDids, parseListUri } =
+  await import('../src/mcp/listMembers.js');
 
 const LIST_URI = 'at://did:plc:creator/app.bsky.graph.list/abc123';
 
@@ -400,5 +401,60 @@ describe('resolveListAvailability', () => {
     assert.equal(result.length, 1);
     assert.equal(result[0].did, 'did:plc:fast');
     assert.equal(sawSignalOnHungCall, true, 'fetchWithTimeout should pass an AbortController signal through');
+  });
+});
+
+describe('resolveAvailabilityForDids (#103 voter-scoped path)', () => {
+  it('resolves only the given DIDs, filtered to records scoped to the list', async () => {
+    fetchImpl = async (url) => {
+      const u = String(url);
+      if (u.startsWith('https://plc.directory/')) {
+        const did = decodeURIComponent(u.replace('https://plc.directory/', ''));
+        return { ok: true, json: async () => pdsDoc(`https://pds.${did.split(':').pop()}.example`) };
+      }
+      if (u.includes('com.atproto.repo.listRecords')) {
+        const repo = new URL(u).searchParams.get('repo');
+        if (repo === 'did:plc:alice') {
+          return { ok: true, json: async () => ({ records: [availabilityRecord('did:plc:alice', {
+            validUntil: new Date(Date.now() + 86400000).toISOString(),
+          })] }) };
+        }
+        return { ok: true, json: async () => ({ records: [] }) }; // bob: no record
+      }
+      throw new Error(`Unexpected fetch: ${u}`);
+    };
+
+    const result = await resolveAvailabilityForDids(['did:plc:alice', 'did:plc:bob'], LIST_URI);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].did, 'did:plc:alice');
+  });
+
+  it('dedupes repeated DIDs and never calls getList', async () => {
+    let getListCalled = false;
+    fetchImpl = async (url) => {
+      const u = String(url);
+      if (u.includes('app.bsky.graph.getList')) { getListCalled = true; return { ok: true, json: async () => ({ items: [] }) }; }
+      if (u.startsWith('https://plc.directory/')) return { ok: true, json: async () => pdsDoc('https://pds.alice.example') };
+      if (u.includes('com.atproto.repo.listRecords')) {
+        return { ok: true, json: async () => ({ records: [availabilityRecord('did:plc:alice', {
+          validUntil: new Date(Date.now() + 86400000).toISOString() })] }) };
+      }
+      throw new Error(`Unexpected fetch: ${u}`);
+    };
+    const result = await resolveAvailabilityForDids(['did:plc:alice', 'did:plc:alice'], LIST_URI);
+    assert.equal(result.length, 1);
+    assert.equal(getListCalled, false, 'voter path must not enumerate the list');
+  });
+
+  it('throws on a malformed list URI rather than silently resolving nothing', async () => {
+    fetchImpl = async () => { throw new Error('should not fetch for a malformed URI'); };
+    await assert.rejects(
+      () => resolveAvailabilityForDids(['did:plc:alice'], 'not-a-list-uri'),
+      /Invalid list URI|Not an app\.bsky\.graph\.list/
+    );
+  });
+
+  it('parseListUri is exported and returns the authority DID', () => {
+    assert.equal(parseListUri(LIST_URI), 'did:plc:creator');
   });
 });

--- a/server/test/scheduleCall.test.js
+++ b/server/test/scheduleCall.test.js
@@ -35,12 +35,14 @@ function member(did, trust, { timezone = 'UTC' } = {}) {
 // behaviour without re-registering mock.module (which must run before the
 // module-under-test is imported, i.e. once, at the top of the file).
 let resolveListAvailabilityImpl;
+let resolveAvailabilityForDidsImpl;
 let bestCallSlotsImpl;
 let sendEmailCalls;
 
 mock.module('../src/mcp/listMembers.js', {
   namedExports: {
     resolveListAvailability: (...args) => resolveListAvailabilityImpl(...args),
+    resolveAvailabilityForDids: (...args) => resolveAvailabilityForDidsImpl(...args),
   },
 });
 
@@ -77,6 +79,9 @@ function resetHooks() {
   fetchCalls = [];
   resolveListAvailabilityImpl = async () => {
     throw new Error('resolveListAvailability should not be called in this test');
+  };
+  resolveAvailabilityForDidsImpl = async () => {
+    throw new Error('resolveAvailabilityForDids should not be called in this test');
   };
   bestCallSlotsImpl = () => {
     throw new Error('bestCallSlots should not be called in this test');
@@ -265,5 +270,73 @@ describe('schedule_call', () => {
       /Phase 1/
     );
     assert.deepEqual(fetchCalls, []);
+  });
+
+  it('(i) voterDids present -> books for exactly those DIDs via resolveAvailabilityForDids, not the whole list', async () => {
+    resetHooks();
+    let listCalled = false;
+    resolveListAvailabilityImpl = async () => { listCalled = true; return []; };
+    resolveAvailabilityForDidsImpl = async (dids, listUri) => {
+      assert.equal(listUri, LIST_URI);
+      assert.deepEqual([...dids].sort(), ['did:plc:alice', 'did:plc:bob']);
+      return [member('did:plc:alice', 'auto'), member('did:plc:bob', 'auto')];
+    };
+    bestCallSlotsImpl = () => [
+      { slot: '2026-07-21T14:00', participants: ['did:plc:alice', 'did:plc:bob'], count: 2 },
+    ];
+
+    const result = JSON.parse(await callTool('schedule_call', {
+      scope: { type: 'atproto-list', value: LIST_URI },
+      durationMinutes: 60, window: WINDOW, title: 'Voted call',
+      voterDids: ['did:plc:alice', 'did:plc:bob'],
+    }, null));
+
+    assert.equal(result.booked, true);
+    assert.equal(listCalled, false, 'whole-list resolution must NOT run when voterDids is given');
+    assert.equal(result.coverage.withRecords, 2);
+    assert.equal(result.coverage.voters, 2);
+    assert.equal(result.coverage.votersWithoutRecords, 0);
+  });
+
+  it('(j) a voter with no record is a coverage miss -> falls back, does not widen the set', async () => {
+    resetHooks();
+    resolveAvailabilityForDidsImpl = async () => [member('did:plc:alice', 'auto')]; // only 1 of 2 has a record
+    const result = JSON.parse(await callTool('schedule_call', {
+      scope: { type: 'atproto-list', value: LIST_URI },
+      durationMinutes: 60, window: WINDOW, title: 'Voted call',
+      voterDids: ['did:plc:alice', 'did:plc:ghost'],
+    }, null));
+    assert.equal(result.booked, false);
+    assert.equal(result.fallback, 'create_poll');
+  });
+
+  it('(k) voterDids present but empty is a caller error, not a silent poll fallback', async () => {
+    resetHooks();
+    await assert.rejects(
+      () => callTool('schedule_call', {
+        scope: { type: 'atproto-list', value: LIST_URI },
+        durationMinutes: 60, window: WINDOW, title: 'x', voterDids: [],
+      }, null),
+      /voterDids.*non-empty|non-empty.*voterDids/i
+    );
+    assert.deepEqual(fetchCalls, []);
+  });
+
+  it('(l) a non-array (or non-DID) voterDids is rejected', async () => {
+    resetHooks();
+    await assert.rejects(
+      () => callTool('schedule_call', {
+        scope: { type: 'atproto-list', value: LIST_URI },
+        durationMinutes: 60, window: WINDOW, title: 'x', voterDids: 'did:plc:alice',
+      }, null),
+      /voterDids must be an array/i
+    );
+    await assert.rejects(
+      () => callTool('schedule_call', {
+        scope: { type: 'atproto-list', value: LIST_URI },
+        durationMinutes: 60, window: WINDOW, title: 'x', voterDids: ['not-a-did'],
+      }, null),
+      /voterDids must be an array/i
+    );
   });
 });


### PR DESCRIPTION
First slice of Phase 2 (#103 / #119): `schedule_call` can now book for an **explicit set of voter DIDs** — the people who opted into a specific proposal — instead of only the whole list. This is the direct implementation of #119's "book for who voted."

Plan: `docs/plans/2026-07-17-phase2-voter-scoped-booking.md`.

## What changed

**`voterDids` — an optional argument on `schedule_call`.**

- **present** → resolve availability for exactly those DIDs, then run the identical overlap → coverage → trust → book pipeline
- **absent** → unchanged whole-list behaviour

```js
schedule_call({ scope, durationMinutes, window, title, voterDids: ['did:plc:…', …] })
```

Two commits:

1. **Refactor** — extracted `resolveAvailabilityForDids(dids, listUri)` from `resolveListAvailability`, which is now a thin caller (enumerate the list → hand the DIDs to the shared resolver). Behaviour-preserving: all 11 existing `resolveListAvailability` tests stay green.
2. **Feature** — `voterDids` validation + resolution branch + schema. Everything downstream (coverage floors, `bestCallSlots`, trust split, ICS) is untouched.

## The design question, resolved not fudged

**Which of a voter's records counts?** The one scoped to the proposal's list — because a record's `scope` *is* the opt-in (the exact #110 principle). So a voter who liked but never published availability for this list is a **coverage miss**, correct by construction. No list-membership check is needed; the scoped record is the membership.

That also means **D6 (quorum) and D7 (thin-coverage floor) need no new decision** — the existing `MIN_CALL_COVERAGE` floors apply as-is. A voter without a usable record can't be placed; too few placeable voters → the same `create_poll` fallback.

## Two self-decisions (flagged, not blocking)

- **An argument, not a new tool.** DRY, backward-compatible, one contract to keep in sync.
- **`voterDids: []` throws** ("must be non-empty") rather than silently falling back to a poll — today's "fail loud" lesson, so a caller bug can't masquerade as thin coverage. A non-array or a non-`did:` entry throws too.

## Channel-agnostic (kept)

avails receives DIDs and never learns *how* they voted (a Bluesky like, an MC vote, a Telegram reaction). The name `voterDids` reflects the epic's concept; the tool interprets nothing about the source. The response's `coverage` now also reports `voters` and `votersWithoutRecords` so CA can message "3 of 5 voters haven't published availability."

## Out of scope (tracked)

- **How CA reaches this** (MCP vs. a thin REST route) — Phase 2's integration step, alongside the CA proposal-post + `getLikes` tally (Option A, #119). This PR is the avails *capability*.
- **Telegram as a voter source** waits on #122 (are reactions attributable?) and #33 (Telegram id → DID).

## Verification

- **126/126** server tests (118 baseline + 8 new). `node --check` clean on both changed source files.
- The 4 refactor tests exercise `resolveAvailabilityForDids` against **real fetch mocks** (not a mocked resolver), including the malformed-URI-throws case.
- **Post-deploy smoke available** (couldn't before): call `schedule_call` with `voterDids: ['did:plc:7t3rryg4ck5ifux2jokclglk']` (the one real record) against the Standing Avails Test list — expect `withRecords: 1`, `voters: 1`, fallback (1 < 2). That proves the voter path resolves a real record end to end, the same way #110 was verified. Reaching `booked: true` still needs a second real record.
