### PR TITLE
Service-repo response store (#42 Stage 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ The **client has no test runner** — `cd client && npm run build` is the only c
 
 - **Every write endpoint MUST have validation middleware.** A missing middleware on the PUT response route caused silent data corruption (2026-04-07). Routes use `req.validatedBody` (not `req.body`).
 - **Session restore must happen after `app.listen()`.** The OAuth client fetches `client-metadata.json` from itself during restore — starting before listening causes a deadlock.
-- **Anonymous responses require creator's session.** If the creator's session expires or is lost, participants can't submit.
+- **Responses write to avails' own service repo (`AVAILS_SERVICE_*`); the creator's session is not on the response path** (#42). When the service identity is unconfigured, the legacy creator-session path applies (and can 503 if the creator is signed out). New response records live in avails' repo; reads merge creator (legacy) + service repos. See `docs/architecture.md` → Service identity.
 - **Never pass inline `new Set()` / `{}` as React prop defaults.** Use module-level constants. AvailGrid is sensitive to unstable references — causes render loops.
 - **Never place hooks after early returns.** React error #310 ("Rendered more hooks than during the previous render").
 - **`AvailGrid` and `SchedulingGrid` duplicate the grid** (layout, pagination, drag-select, and keyboard/ARIA) — they render the same data and must stay in sync; a change to one almost always belongs in both. Both are keyboard-operable (roving `tabIndex` + arrow/Space) and viewport-aware; preserve that. The availability heatmap's redundant non-color cue is interaction-based (tap-to-reveal + aria-label count), not an in-cell number — see DESIGN.md.
@@ -66,6 +66,9 @@ Railway (single service, Nixpacks builder). Custom domain: avails.zhgnv.com.
 - `ATPROTO_PRIVATE_KEY` — base64-encoded ES256 JWK (Railway mangles raw JSON)
 - `SESSION_SECRET` — cookie signing
 - `MCP_JWT_SECRET` — optional, JWT signing for MCP tokens (falls back to SESSION_SECRET)
+- `AVAILS_SERVICE_IDENTIFIER` — avails' own ATProto account (handle or DID) for the service-repo response store (#42). Setting this + `AVAILS_SERVICE_APP_PASSWORD` **activates** the service path; unset = legacy creator-session writes.
+- `AVAILS_SERVICE_APP_PASSWORD` — app password for that account (not the login password)
+- `AVAILS_SERVICE_PDS` — optional; the account's PDS host for login (default `https://bsky.social`)
 - `TELEGRAM_BOT_TOKEN` — Avails bot token for share_poll
 - `RESEND_API_KEY` — email service
 - `CLIENT_URL` — deployed URL (for redirects and email links)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ Read this file when working on avails internals. Not loaded every session — re
 
 There is no database. ATProto PDS is the data store:
 - **Polls**: `chat.avails.scheduling.poll` records in creator's PDS
-- **Responses**: `chat.avails.scheduling.response` records in creator's PDS (anonymous responses written using creator's stored OAuth session)
+- **Responses**: `chat.avails.scheduling.response` records. New responses are written to avails' **own service repo** (see [Service identity](#service-identity)); pre-#42 responses remain in the creator's PDS. Reads merge both. When the service identity is unconfigured, writes fall back to the creator's PDS via the creator's OAuth session (the legacy behavior).
 - **Standing availability**: `chat.avails.scheduling.availability` records in the **participant's own PDS** — the one record type that isn't creator-hosted. See [Standing availability](#standing-availability) below.
 - **Poll index**: Map (`lib/pollIndex.js`) for community-based discovery. Persisted to Railway volume via `persistence.js` (auto-save every 30s, restored on startup).
 - **Sessions**: persisted to Railway volume as JSON (`/data/oauth-sessions.json`, `/data/app-sessions.json`). Restored on startup AFTER server starts listening (critical — session restore fetches client-metadata from itself).
@@ -21,8 +21,18 @@ There is no database. ATProto PDS is the data store:
 1. User enters Bluesky handle → server redirects to ATProto auth server
 2. Auth server redirects back to `/api/auth/callback`
 3. Server stores OAuth session (keyed by DID) + app session (keyed by cookie)
-4. Creator's OAuth session is used for all PDS writes (including anonymous participant responses)
+4. Creator's OAuth session is used for the creator's own PDS writes (poll create/finalize/unschedule). Participant **responses** no longer ride the creator's session — they go to avails' service repo (see [Service identity](#service-identity)); only the legacy fallback path still uses the creator's session for responses.
 5. Private key for `private_key_jwt` auth stored as base64-encoded JWK in `ATPROTO_PRIVATE_KEY` env var
+
+## Service identity
+
+avails has its own ATProto account (a `did:plc`, app-password auth — **not** OAuth; #77 investigated did:web and deferred it). `lib/serviceSession.js` logs in via `com.atproto.server.createSession` and refreshes on expiry, exposing authenticated `serviceCreateRecord`/`servicePutRecord`/`serviceDeleteRecord`/`serviceGetRecord`.
+
+- **Why:** a poll response used to be written with the *creator's* OAuth session into the creator's PDS, so a signed-out creator meant participants got a 503 (#72, #117). Responses now write to avails' own repo, decoupled from any user session.
+- **Feature-flagged (`isServiceConfigured()`):** true iff `AVAILS_SERVICE_IDENTIFIER` + `AVAILS_SERVICE_APP_PASSWORD` are set. Unset → every response route falls back to the legacy creator-session path unchanged, so the code deploys as a no-op until the env vars activate it.
+- **Reads** (`lib/responseReads.js`) merge two public `listRecords` — creator repo (legacy) + service repo (new), paged and filtered by `pollUri`, each tagged `home: 'creator' | 'service'`. Public/unauthenticated; a read never depends on the service *login*, only on resolving the service DID.
+- **Edit/delete** disambiguate with a service `getRecord`: a record present in the service repo is edited there; otherwise the creator-session legacy path handles it (pre-migration records only).
+- **Scope note (Stage 1):** Stage 2 — authenticated respondents writing to *their own* PDS — and private-scope responses are out of scope (avails#42).
 
 ## Server infrastructure
 
@@ -37,7 +47,7 @@ There is no database. ATProto PDS is the data store:
 ## Key gotchas (full context)
 
 - **Session restore must happen after `app.listen()`** — the OAuth client fetches `client-metadata.json` from itself during restore. Starting restore before listening causes a deadlock.
-- **Anonymous responses require creator's session** — if the creator's session expires or is lost, participants can't submit. Sessions persist to Railway volume to survive deploys.
+- **Responses write to avails' service repo, not the creator's session** (#42) — see [Service identity](#service-identity). The creator's session is off the response path when the service identity is configured; the legacy fallback (creator-session write, which can 503 if the creator is signed out) applies only when it isn't.
 - **Old polls use different field names** — `earliestTime`/`latestTime`/`slotDuration` vs `timeRange`/`slotMinutes`. PollView has fallback handling for both formats.
 - **React render loops and hooks** — AvailGrid is sensitive to unstable object references in props. Never pass `new Set()` or `{}` inline as prop defaults. Use module-level constants (`const EMPTY_SET = new Set()`) and assign fallbacks in the function body, not destructuring. The SchedulingGrid was created as a separate component (instead of adding props to AvailGrid) specifically to avoid this. Also: never place hooks (`useMemo`, `useEffect`, etc.) after early returns — React error #310 ("Rendered more hooks than during the previous render").
 - **Document-level event handlers and stale closures** — AvailGrid attaches `pointerup`/`pointermove` to `document`. These handlers must use refs (not state) to read mutable values, or the `useCallback` dependency array causes constant listener teardown/re-add. Pattern: `activeSlotRef` mirrors `activeSlot` state; handler reads ref, state is only for rendering.
@@ -201,7 +211,7 @@ Expect a `Failed to restore OAuth session … invalid_client_metadata` warning o
 
 ## Known architectural debts
 
-- **Response storage coupled to creator session** (#42) — responses written to creator's PDS, sessions persist to volume but architecture limits data ownership and scaling.
+- ~~**Response storage coupled to creator session** (#42)~~ — RESOLVED (Stage 1) by the service identity: new responses write to avails' own repo, reads merge creator+service (see [Service identity](#service-identity)). Remaining: Stage 2 (authenticated respondents own their responses in their own PDS) and private-scope responses.
 - **OAuth scope upgrade doesn't re-prompt** (#49) — ATProto OAuth caches grants; adding new scopes (like the OpenMeet RPC scope) doesn't trigger re-consent. Use admin clear-sessions endpoint + wait for bsky.social propagation (up to 15 min).
 - **No OG metadata** (#46) — poll links show no preview in Telegram/Slack/social media.
 - **ATProto DID URLs** (#45) — poll URLs contain long DIDs; slug-based URLs planned.

--- a/docs/plans/2026-07-18-service-repo-reliability.md
+++ b/docs/plans/2026-07-18-service-repo-reliability.md
@@ -1,0 +1,632 @@
+# Service-Repo Reliability Pass (#42 Stage 1) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop writing poll responses through the *creator's* OAuth session. Give avails its own ATProto service identity and write all new responses to its own repo, so a response no longer depends on the creator being signed in — deleting the 503 failure class (#72, #117) and the "anonymous responses require creator's session" hard constraint.
+
+**Architecture:** A new `serviceSession.js` logs avails into a dedicated ATProto account via app-password (`com.atproto.server.createSession` + refresh loop) and exposes authenticated XRPC writes. The response write routes (`responses.js`) write to the **service repo** instead of the creator's. Reads (`polls.js`, 3 sites) merge two public `listRecords` — the creator repo (legacy responses only) and the service repo (all new responses) — filtered by `pollUri`, tagging each with its home. **The entire new path is gated behind `isServiceConfigured()`**: when the service env vars are absent, every route falls back to today's exact creator-session behavior. So the PR merges and deploys as a no-op; setting two env vars activates it.
+
+**Tech Stack:** Express 4 (ES modules, `server/`), raw ATProto XRPC over `fetch` (the repo has **no** `@atproto/api` dependency — do not add one), Node built-in test runner (`node:test`, `--experimental-test-module-mocks`).
+
+**Source of truth:** Citizen-Infra/avails#42 (design-resolution comment, 2026-07-18) + #77 (did:plc service identity). This is Stage 1 only — authenticated respondents writing to *their own* PDS (Stage 2) and private-scope responses are explicitly out of scope (see #42).
+
+## Global Constraints
+
+- **No `@atproto/api`.** Use raw XRPC over `fetch`, mirroring `responses.js` / `tools.js`. Adding the SDK is out of scope.
+- **The new path is feature-flagged, always.** Every write/read branch checks `isServiceConfigured()`. Configured → service path. Not configured → the current creator-session code, byte-for-byte in behavior. This is what lets the PR deploy before the account exists. Never remove the fallback in this PR.
+- **Reads are public and unauthenticated.** `listRecords` against any repo needs no auth. The read path must NOT depend on the service *login* succeeding — only on knowing the service DID (resolved + cached from the handle). If service identity resolution fails, degrade to creator-repo responses only; never 503 a read.
+- **Full cursor paging on the service-repo read.** The service repo accumulates responses across *all* polls, so a single `limit=100` call can miss a poll's responses once the repo exceeds 100 records total. Page with `cursor` until exhausted, with a sane page cap; if the cap is hit, `console.warn` — never silently truncate.
+- **Record shape is unchanged.** The response record still carries `pollUri: at://<creatorDid>/chat.avails.scheduling.poll/<rkey>`, so it is self-describing regardless of which repo holds it. The read filter (`pollUri` matches this poll) works across both repos identically.
+- **Tests:** `node:test` + `node:assert`; the suite globs `test/*.test.js` (a new test file is gated automatically — never edit `package.json`). Mock the service layer the way `test/responses.test.js` mocks the session layer. Syntax check: `node --check server/src/<file>.js`.
+- **No behavior change to poll create/finalize/unschedule.** Those write the *creator's own* records with the creator's session when the creator is present — that coupling is correct and stays. Only the response write path and the response *read merge* change.
+
+---
+
+## The activation model (read before Task 1)
+
+`isServiceConfigured()` is true iff `AVAILS_SERVICE_IDENTIFIER` and `AVAILS_SERVICE_APP_PASSWORD` are both set. This single predicate governs the whole change:
+
+| | `isServiceConfigured()` false (today, and post-deploy pre-provision) | true (after env vars set) |
+|---|---|---|
+| **POST response** | creator session → creator repo (current code; 503 if creator signed out) | service session → service repo (no 503) |
+| **PUT/DELETE response** | creator session → creator repo | service `getRecord` to disambiguate: in service repo → service session; else → creator session (legacy, may 503) |
+| **Read merge** | creator repo only (current code) | creator repo (legacy) + service repo (new), merged |
+
+Consequence for sequencing: **the code ships dark.** Merge + deploy changes nothing. Provisioning the account and setting the two env vars is the activation switch, reversible by unsetting them. The real-PDS smoke (Task 6) happens after activation.
+
+---
+
+## File Structure
+
+**Create:**
+- `server/src/lib/serviceSession.js` — service identity: `isServiceConfigured()`, `getServiceIdentity()` (resolve+cache did/pds), authenticated `serviceCreateRecord`/`servicePutRecord`/`serviceDeleteRecord`/`serviceGetRecord` with refresh+re-login.
+- `server/src/lib/responseReads.js` — `fetchPollResponses(creatorDid, rkey)`: public paged read of creator repo + service repo, filtered by `pollUri`, each tagged `{ home: 'creator' | 'service' }`.
+- `server/test/serviceSession.test.js`, `server/test/responseReads.test.js`.
+
+**Modify:**
+- `server/src/routes/responses.js` — branch POST/PUT/DELETE on `isServiceConfigured()`.
+- `server/src/routes/polls.js` — replace the three inline response-read blocks (lines ~136, ~248, ~344) with `fetchPollResponses`.
+- `server/test/responses.test.js` — update for the branched write path (the 503-only-when-not-configured case; the service-write case).
+- `docs/architecture.md`, `CLAUDE.md` — service-identity section; delete the "anonymous responses require creator's session" hard constraint; env vars.
+
+---
+
+## Task 1: Service session module
+
+**Files:**
+- Create: `server/src/lib/serviceSession.js`
+- Test: `server/test/serviceSession.test.js`
+
+**Interfaces:**
+- Produces:
+  - `isServiceConfigured(): boolean` — both env vars present.
+  - `async getServiceIdentity(): { did, pds }` — resolves the identifier's DID + PDS endpoint (public), cached module-level. Throws if not configured.
+  - `async serviceCreateRecord(collection, record): { uri, cid }`
+  - `async servicePutRecord(collection, rkey, record): { uri, cid }`
+  - `async serviceDeleteRecord(collection, rkey): void`
+  - `async serviceGetRecord(collection, rkey): object | null` — null on 404 (used to disambiguate service vs legacy).
+- Consumes: `globalThis.fetch` only.
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+// serviceSession caches identity + tokens at module scope; import fresh per concern
+// via a query-string cache-bust so each test starts clean.
+const originalFetch = globalThis.fetch;
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env = { ...originalEnv };
+  globalThis.fetch = originalFetch;
+});
+
+test('isServiceConfigured reflects both env vars', async () => {
+  const mod = await import('../src/lib/serviceSession.js?case=cfg');
+  delete process.env.AVAILS_SERVICE_IDENTIFIER;
+  delete process.env.AVAILS_SERVICE_APP_PASSWORD;
+  assert.equal(mod.isServiceConfigured(), false);
+  process.env.AVAILS_SERVICE_IDENTIFIER = 'avails.zhgnv.com';
+  process.env.AVAILS_SERVICE_APP_PASSWORD = 'app-pw';
+  assert.equal(mod.isServiceConfigured(), true);
+});
+
+test('serviceCreateRecord logs in once, then writes with the access token', async () => {
+  process.env.AVAILS_SERVICE_IDENTIFIER = 'avails.zhgnv.com';
+  process.env.AVAILS_SERVICE_APP_PASSWORD = 'app-pw';
+  process.env.AVAILS_SERVICE_PDS = 'https://pds.test';
+  const calls = [];
+  globalThis.fetch = async (url, opts = {}) => {
+    const u = String(url); calls.push(u);
+    if (u.includes('com.atproto.server.createSession')) {
+      return { ok: true, json: async () => ({ accessJwt: 'A1', refreshJwt: 'R1', did: 'did:plc:svc' }) };
+    }
+    if (u.includes('com.atproto.repo.createRecord')) {
+      assert.equal(opts.headers.Authorization, 'Bearer A1');
+      return { ok: true, json: async () => ({ uri: 'at://did:plc:svc/c/xyz', cid: 'cid1' }) };
+    }
+    throw new Error(`unexpected ${u}`);
+  };
+  const mod = await import('../src/lib/serviceSession.js?case=create');
+  const r = await mod.serviceCreateRecord('chat.avails.scheduling.response', { pollUri: 'at://x/y/z' });
+  assert.equal(r.uri, 'at://did:plc:svc/c/xyz');
+  assert.equal(calls.filter((c) => c.includes('createSession')).length, 1);
+});
+
+test('an expired access token triggers refresh then retry', async () => {
+  process.env.AVAILS_SERVICE_IDENTIFIER = 'avails.zhgnv.com';
+  process.env.AVAILS_SERVICE_APP_PASSWORD = 'app-pw';
+  process.env.AVAILS_SERVICE_PDS = 'https://pds.test';
+  let wrote = 0;
+  globalThis.fetch = async (url, opts = {}) => {
+    const u = String(url);
+    if (u.includes('createSession')) return { ok: true, json: async () => ({ accessJwt: 'A1', refreshJwt: 'R1', did: 'did:plc:svc' }) };
+    if (u.includes('refreshSession')) {
+      assert.equal(opts.headers.Authorization, 'Bearer R1');
+      return { ok: true, json: async () => ({ accessJwt: 'A2', refreshJwt: 'R2', did: 'did:plc:svc' }) };
+    }
+    if (u.includes('createRecord')) {
+      if (opts.headers.Authorization === 'Bearer A1') {
+        return { ok: false, status: 400, json: async () => ({ error: 'ExpiredToken' }), text: async () => 'ExpiredToken' };
+      }
+      assert.equal(opts.headers.Authorization, 'Bearer A2'); wrote++;
+      return { ok: true, json: async () => ({ uri: 'at://did:plc:svc/c/ok', cid: 'c' }) };
+    }
+    throw new Error(`unexpected ${u}`);
+  };
+  const mod = await import('../src/lib/serviceSession.js?case=refresh');
+  const r = await mod.serviceCreateRecord('c', { pollUri: 'p' });
+  assert.equal(r.uri, 'at://did:plc:svc/c/ok');
+  assert.equal(wrote, 1);
+});
+
+test('serviceGetRecord returns null on 404', async () => {
+  process.env.AVAILS_SERVICE_IDENTIFIER = 'avails.zhgnv.com';
+  process.env.AVAILS_SERVICE_APP_PASSWORD = 'app-pw';
+  process.env.AVAILS_SERVICE_PDS = 'https://pds.test';
+  globalThis.fetch = async (url) => {
+    const u = String(url);
+    if (u.includes('createSession')) return { ok: true, json: async () => ({ accessJwt: 'A1', refreshJwt: 'R1', did: 'did:plc:svc' }) };
+    if (u.includes('getRecord')) return { ok: false, status: 404, text: async () => 'not found' };
+    throw new Error(`unexpected ${u}`);
+  };
+  const mod = await import('../src/lib/serviceSession.js?case=get404');
+  assert.equal(await mod.serviceGetRecord('c', 'missing'), null);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd server && node --test test/serviceSession.test.js`
+Expected: FAIL (module missing).
+
+- [ ] **Step 3: Implement**
+
+```js
+// server/src/lib/serviceSession.js
+// avails' own ATProto identity. Writes poll responses to avails' own repo so a
+// response no longer depends on the creator's OAuth session (#42). App-password
+// auth (createSession/refreshSession) — NOT OAuth; this is a headless service
+// credential, not a user grant. Feature-flagged: when the env vars are absent,
+// callers fall back to the legacy creator-session path.
+
+const IDENTIFIER = () => process.env.AVAILS_SERVICE_IDENTIFIER;
+const APP_PASSWORD = () => process.env.AVAILS_SERVICE_APP_PASSWORD;
+const CONFIGURED_PDS = () => process.env.AVAILS_SERVICE_PDS; // optional override
+
+export function isServiceConfigured() {
+  return Boolean(IDENTIFIER() && APP_PASSWORD());
+}
+
+let identity = null;   // { did, pds }
+let tokens = null;     // { accessJwt, refreshJwt }
+
+async function resolvePdsForDid(did) {
+  const res = await fetch(`https://plc.directory/${encodeURIComponent(did)}`);
+  if (!res.ok) throw new Error(`resolve PDS for ${did}: ${res.status}`);
+  const doc = await res.json();
+  const svc = doc.service?.find((s) => s.id === '#atproto_pds' || s.type === 'AtprotoPersonalDataServer');
+  return svc?.serviceEndpoint || 'https://bsky.social';
+}
+
+// The host we call createSession against IS the account's PDS. Prefer an explicit
+// AVAILS_SERVICE_PDS; else default to bsky.social for login, then trust the DID's
+// resolved PDS for reads/writes.
+function loginHost() {
+  return CONFIGURED_PDS() || 'https://bsky.social';
+}
+
+async function login() {
+  if (!isServiceConfigured()) throw new Error('service identity not configured');
+  const res = await fetch(`${loginHost()}/xrpc/com.atproto.server.createSession`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ identifier: IDENTIFIER(), password: APP_PASSWORD() }),
+  });
+  if (!res.ok) throw new Error(`service login failed: ${res.status} ${await res.text().catch(() => '')}`);
+  const data = await res.json();
+  tokens = { accessJwt: data.accessJwt, refreshJwt: data.refreshJwt };
+  identity = { did: data.did, pds: CONFIGURED_PDS() || (await resolvePdsForDid(data.did)) };
+  return identity;
+}
+
+export async function getServiceIdentity() {
+  if (identity) return identity;
+  return login();
+}
+
+async function refresh() {
+  const res = await fetch(`${loginHost()}/xrpc/com.atproto.server.refreshSession`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${tokens.refreshJwt}` },
+  });
+  if (!res.ok) { await login(); return; }        // refresh dead → full re-login
+  const data = await res.json();
+  tokens = { accessJwt: data.accessJwt, refreshJwt: data.refreshJwt };
+}
+
+// Authenticated XRPC POST against the service PDS, refreshing+retrying once on an
+// expired/invalid token.
+async function authedXrpc(method, body, { retry = true } = {}) {
+  const id = await getServiceIdentity();
+  if (!tokens) await login();
+  const doCall = () => fetch(`${id.pds}/xrpc/${method}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${tokens.accessJwt}` },
+    body: JSON.stringify(body),
+  });
+  let res = await doCall();
+  if (!res.ok && retry) {
+    const text = await res.text().catch(() => '');
+    if (res.status === 400 || res.status === 401) {
+      if (/ExpiredToken|InvalidToken|AuthenticationRequired/i.test(text)) {
+        await refresh();
+        res = await doCall();
+      } else {
+        throw new Error(`${method} failed (${res.status}): ${text}`);
+      }
+    } else {
+      throw new Error(`${method} failed (${res.status}): ${text}`);
+    }
+  }
+  if (!res.ok) throw new Error(`${method} failed (${res.status}): ${await res.text().catch(() => '')}`);
+  return res.json();
+}
+
+export async function serviceCreateRecord(collection, record) {
+  const { did } = await getServiceIdentity();
+  return authedXrpc('com.atproto.repo.createRecord', { repo: did, collection, record });
+}
+
+export async function servicePutRecord(collection, rkey, record) {
+  const { did } = await getServiceIdentity();
+  return authedXrpc('com.atproto.repo.putRecord', { repo: did, collection, rkey, record });
+}
+
+export async function serviceDeleteRecord(collection, rkey) {
+  const { did } = await getServiceIdentity();
+  await authedXrpc('com.atproto.repo.deleteRecord', { repo: did, collection, rkey });
+}
+
+// Public read against the service repo — no auth needed, but we reuse the resolved
+// PDS. Returns null on 404 so callers can disambiguate a service record from a
+// legacy creator-repo one.
+export async function serviceGetRecord(collection, rkey) {
+  const { did, pds } = await getServiceIdentity();
+  const url = `${pds}/xrpc/com.atproto.repo.getRecord?repo=${encodeURIComponent(did)}&collection=${encodeURIComponent(collection)}&rkey=${encodeURIComponent(rkey)}`;
+  const res = await fetch(url);
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`getRecord failed (${res.status})`);
+  return res.json();
+}
+
+// Test-only: reset cached identity/tokens.
+export function __resetForTest() { identity = null; tokens = null; }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd server && node --test test/serviceSession.test.js`
+Expected: PASS (4 tests). Then `node --check server/src/lib/serviceSession.js`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/lib/serviceSession.js server/test/serviceSession.test.js
+git commit -m "feat(service): app-password ATProto service identity for response writes (#42)"
+```
+
+---
+
+## Task 2: Shared response-read helper (creator + service merge)
+
+**Files:**
+- Create: `server/src/lib/responseReads.js`
+- Test: `server/test/responseReads.test.js`
+
+**Interfaces:**
+- Produces: `async fetchPollResponses(creatorDid, rkey): Array<{ ...responseValue, uri, cid, home }>` — merges the creator repo (legacy) and, when `isServiceConfigured()`, the service repo, each `listRecords` paged to exhaustion and filtered to `pollUri` ending in `/<rkey>`. `home` is `'creator'` or `'service'`.
+- Consumes: a shared `resolvePds` (extract the copy in `responses.js`/`polls.js` or duplicate — a 6-line helper; do not over-abstract), `getServiceIdentity`/`isServiceConfigured` from Task 1.
+
+- [ ] **Step 1: Write the failing test** — mock `globalThis.fetch`: creator repo returns one legacy response for this poll (+ one for a different poll, which must be filtered out); service repo (when configured) returns two, one across a cursor page boundary. Assert: correct count, `home` tags, cross-poll filtering, both pages included.
+
+```js
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+const originalFetch = globalThis.fetch;
+const originalEnv = { ...process.env };
+beforeEach(() => { process.env = { ...originalEnv }; globalThis.fetch = originalFetch; });
+
+test('merges creator (legacy) + service responses, tags home, filters by poll, pages', async () => {
+  process.env.AVAILS_SERVICE_IDENTIFIER = 'avails.zhgnv.com';
+  process.env.AVAILS_SERVICE_APP_PASSWORD = 'pw';
+  process.env.AVAILS_SERVICE_PDS = 'https://svc.pds';
+  const CREATOR = 'did:plc:creator';
+  globalThis.fetch = async (url) => {
+    const u = String(url);
+    if (u.includes('plc.directory')) return { ok: true, json: async () => ({ service: [{ id: '#atproto_pds', serviceEndpoint: 'https://creator.pds' }] }) };
+    if (u.includes('createSession')) return { ok: true, json: async () => ({ accessJwt: 'A', refreshJwt: 'R', did: 'did:plc:svc' }) };
+    if (u.includes('creator.pds') && u.includes('listRecords')) {
+      return { ok: true, json: async () => ({ records: [
+        { uri: 'at://c/r/leg1', cid: 'c1', value: { pollUri: `at://${CREATOR}/p/poll1`, name: 'Legacy' } },
+        { uri: 'at://c/r/other', cid: 'c9', value: { pollUri: `at://${CREATOR}/p/OTHER`, name: 'Nope' } },
+      ] }) };
+    }
+    if (u.includes('svc.pds') && u.includes('listRecords')) {
+      if (!u.includes('cursor=')) return { ok: true, json: async () => ({ cursor: 'pg2', records: [
+        { uri: 'at://s/r/s1', cid: 's1', value: { pollUri: `at://${CREATOR}/p/poll1`, name: 'New1' } },
+      ] }) };
+      return { ok: true, json: async () => ({ records: [
+        { uri: 'at://s/r/s2', cid: 's2', value: { pollUri: `at://${CREATOR}/p/poll1`, name: 'New2' } },
+      ] }) };
+    }
+    throw new Error(`unexpected ${u}`);
+  };
+  const { fetchPollResponses } = await import('../src/lib/responseReads.js?case=merge');
+  const out = await fetchPollResponses(CREATOR, 'poll1');
+  const names = out.map((r) => r.name).sort();
+  assert.deepEqual(names, ['Legacy', 'New1', 'New2']);
+  assert.equal(out.find((r) => r.name === 'Legacy').home, 'creator');
+  assert.equal(out.find((r) => r.name === 'New2').home, 'service');
+});
+
+test('when service not configured, returns creator responses only', async () => {
+  delete process.env.AVAILS_SERVICE_IDENTIFIER;
+  delete process.env.AVAILS_SERVICE_APP_PASSWORD;
+  globalThis.fetch = async (url) => {
+    const u = String(url);
+    if (u.includes('plc.directory')) return { ok: true, json: async () => ({ service: [{ id: '#atproto_pds', serviceEndpoint: 'https://creator.pds' }] }) };
+    if (u.includes('listRecords')) return { ok: true, json: async () => ({ records: [
+      { uri: 'at://c/r/1', cid: 'c1', value: { pollUri: 'at://did:plc:creator/p/poll1', name: 'Only' } },
+    ] }) };
+    throw new Error(`unexpected ${u}`);
+  };
+  const { fetchPollResponses } = await import('../src/lib/responseReads.js?case=nocfg');
+  const out = await fetchPollResponses('did:plc:creator', 'poll1');
+  assert.deepEqual(out.map((r) => r.name), ['Only']);
+});
+```
+
+- [ ] **Step 2: Run → FAIL.** `cd server && node --test test/responseReads.test.js`
+
+- [ ] **Step 3: Implement**
+
+```js
+// server/src/lib/responseReads.js
+import { isServiceConfigured, getServiceIdentity } from './serviceSession.js';
+
+const RESPONSE_COLLECTION = 'chat.avails.scheduling.response';
+const MAX_PAGES = 20; // 20 * 100 = 2000 records; warn if exceeded rather than truncate silently
+
+async function resolvePds(did) {
+  const res = await fetch(`https://plc.directory/${encodeURIComponent(did)}`);
+  if (!res.ok) throw new Error(`resolve PDS ${did}: ${res.status}`);
+  const doc = await res.json();
+  const svc = doc.service?.find((s) => s.id === '#atproto_pds' || s.type === 'AtprotoPersonalDataServer');
+  return svc?.serviceEndpoint || 'https://bsky.social';
+}
+
+// Page listRecords on `repo`@`pds` for the response collection, keeping records
+// whose pollUri belongs to `rkey`. Public/unauthenticated.
+async function pagedResponses(pds, repo, rkey, home) {
+  const out = [];
+  let cursor;
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const url = `${pds}/xrpc/com.atproto.repo.listRecords?repo=${encodeURIComponent(repo)}&collection=${encodeURIComponent(RESPONSE_COLLECTION)}&limit=100${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ''}`;
+    const res = await fetch(url);
+    if (!res.ok) break;                       // a down repo yields no rows, never throws a read
+    const data = await res.json();
+    for (const r of data.records || []) {
+      if (r.value?.pollUri && r.value.pollUri.endsWith(`/${rkey}`)) {
+        out.push({ ...r.value, uri: r.uri, cid: r.cid, home });
+      }
+    }
+    cursor = data.cursor;
+    if (!cursor) return out;
+  }
+  console.warn(`[responseReads] hit MAX_PAGES for ${repo} poll ${rkey} — response list may be truncated`);
+  return out;
+}
+
+// All responses for a poll, from the creator repo (legacy) + the service repo (new).
+export async function fetchPollResponses(creatorDid, rkey) {
+  const results = [];
+  try {
+    const creatorPds = await resolvePds(creatorDid);
+    results.push(...await pagedResponses(creatorPds, creatorDid, rkey, 'creator'));
+  } catch (err) {
+    console.warn(`[responseReads] creator repo read failed for ${creatorDid}:`, err.message);
+  }
+  if (isServiceConfigured()) {
+    try {
+      const { did, pds } = await getServiceIdentity();
+      results.push(...await pagedResponses(pds, did, rkey, 'service'));
+    } catch (err) {
+      console.warn('[responseReads] service repo read failed:', err.message);
+    }
+  }
+  return results;
+}
+```
+
+- [ ] **Step 4: Run → PASS.** Then `node --check server/src/lib/responseReads.js`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/lib/responseReads.js server/test/responseReads.test.js
+git commit -m "feat(reads): merge creator + service repo responses, paged and poll-filtered (#42)"
+```
+
+---
+
+## Task 3: Branch the response write routes on the service flag
+
+**Files:**
+- Modify: `server/src/routes/responses.js`
+- Test: `server/test/responses.test.js`
+
+**Interfaces:**
+- Consumes: `isServiceConfigured`, `serviceCreateRecord`, `servicePutRecord`, `serviceDeleteRecord`, `serviceGetRecord` (Task 1). Keeps the existing `findOauthSessionByDid` for the legacy fallback.
+- Produces: unchanged HTTP contract (`201 { ok, responseCount, responseRkey }` on POST; `200 { ok }` on PUT/DELETE). The 503 is now reachable ONLY on the legacy path (service not configured, or PUT/DELETE of a legacy record).
+
+- [ ] **Step 1: Update the tests** for the branched behavior. Add a service-configured mock and cases; keep the legacy cases guarded by an unset flag. Extend the existing file:
+
+```js
+// Add near the other mocks:
+let serviceCalls = [];
+let serviceHas = new Set(); // rkeys the service repo "contains" (for getRecord disambiguation)
+mock.module('../src/lib/serviceSession.js', {
+  namedExports: {
+    isServiceConfigured: () => process.env.AVAILS_SERVICE_IDENTIFIER === 'on',
+    serviceCreateRecord: async (collection, record) => { serviceCalls.push({ op: 'create', collection, record }); return { uri: 'at://did:plc:svc/chat.avails.scheduling.response/svc123' }; },
+    servicePutRecord: async (collection, rkey, record) => { serviceCalls.push({ op: 'put', rkey, record }); },
+    serviceDeleteRecord: async (collection, rkey) => { serviceCalls.push({ op: 'delete', rkey }); },
+    serviceGetRecord: async (collection, rkey) => (serviceHas.has(rkey) ? { uri: `at://did:plc:svc/c/${rkey}`, value: {} } : null),
+  },
+});
+```
+
+Add cases (in a new `describe('service-configured write path')`, with `beforeEach(() => { process.env.AVAILS_SERVICE_IDENTIFIER = 'on'; serviceCalls = []; serviceHas = new Set(); })` and an `afterEach` clearing the flag):
+
+```js
+it('POST writes to the service repo, not the creator session, and never 503s when creator is signed out', async () => {
+  mockSessions.clear(); // creator NOT signed in
+  const app = createApp();
+  const res = await request(app, 'POST', path, { name: 'Bea', slots: ['2026-07-21T09:00'] });
+  assert.equal(res.status, 201);
+  assert.equal(serviceCalls.length, 1);
+  assert.equal(serviceCalls[0].op, 'create');
+  assert.equal(serviceCalls[0].record.name, 'Bea');
+  assert.equal(serviceCalls[0].record.pollUri.includes(rkey), true);
+  assert.equal(res.body.responseRkey, 'svc123');
+});
+
+it('PUT of a service-repo record uses the service session', async () => {
+  serviceHas.add('resp456');
+  const app = createApp();
+  const res = await request(app, 'PUT', `/api/polls/${did}/${rkey}/responses/resp456`, { name: 'Bea', slots: ['2026-07-21T09:00'] });
+  assert.equal(res.status, 200);
+  assert.equal(serviceCalls.at(-1).op, 'put');
+});
+
+it('PUT of a legacy (creator-repo) record falls back to the creator session', async () => {
+  // serviceHas is empty → getRecord returns null → legacy path
+  mockSessions.set('creator-session', { did, oauthSession: { fetchHandler: mockFetchHandler } });
+  const app = createApp();
+  const res = await request(app, 'PUT', `/api/polls/${did}/${rkey}/responses/legacyRK`, { name: 'Bea', slots: ['2026-07-21T09:00'] });
+  assert.equal(res.status, 200);
+  assert.equal(serviceCalls.length, 0);      // service NOT used
+  assert.ok(lastXrpcCall);                     // creator session WAS used
+});
+```
+
+The existing legacy `describe` blocks keep asserting the current behavior with the flag unset (their `beforeEach` should `delete process.env.AVAILS_SERVICE_IDENTIFIER`). Keep the "returns 503 when creator session is missing" test — but scope it under the legacy (unset-flag) describe, since 503 is now legacy-only.
+
+- [ ] **Step 2: Run → new cases FAIL** (`cd server && node --test --experimental-test-module-mocks test/responses.test.js`).
+
+- [ ] **Step 3: Implement the branch.** In `responses.js`, import the service module, then in each handler:
+
+```js
+import {
+  isServiceConfigured, serviceCreateRecord, servicePutRecord, serviceDeleteRecord, serviceGetRecord,
+} from '../lib/serviceSession.js';
+```
+
+POST handler — replace the creator-session block with:
+```js
+    const pollUri = `at://${did}/${POLL_COLLECTION}/${rkey}`;
+    const record = { $type: RESPONSE_COLLECTION, pollUri, ...req.validatedBody, createdAt: new Date().toISOString() };
+
+    let createdResponseRkey = null;
+    if (isServiceConfigured()) {
+      const createResult = await serviceCreateRecord(RESPONSE_COLLECTION, record);
+      createdResponseRkey = createResult?.uri?.split('/').pop() || null;
+    } else {
+      const creatorSession = await findOauthSessionByDid(did);
+      if (!creatorSession) return res.status(503).json({ error: /* existing message */ });
+      const createResult = await xrpcCall(creatorSession, 'com.atproto.repo.createRecord', { repo: did, collection: RESPONSE_COLLECTION, record });
+      createdResponseRkey = createResult?.uri?.split('/').pop() || null;
+    }
+    const newCount = incrementResponseCount(did, rkey);
+    // ...notification block unchanged (it reads the poll via unauthenticated getRecord)...
+```
+
+PUT handler — disambiguate:
+```js
+    if (isServiceConfigured() && await serviceGetRecord(RESPONSE_COLLECTION, responseRkey)) {
+      await servicePutRecord(RESPONSE_COLLECTION, responseRkey, record);
+    } else {
+      const creatorSession = await findOauthSessionByDid(did);
+      if (!creatorSession) return res.status(503).json({ error: /* existing message */ });
+      await xrpcCall(creatorSession, 'com.atproto.repo.putRecord', { repo: did, collection: RESPONSE_COLLECTION, rkey: responseRkey, record });
+    }
+```
+
+DELETE handler — same disambiguation with `serviceDeleteRecord` vs the existing creator-session delete.
+
+- [ ] **Step 4: Run → PASS** (all cases, both branches). `node --check server/src/routes/responses.js`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/routes/responses.js server/test/responses.test.js
+git commit -m "feat(responses): write to the service repo when configured, legacy fallback otherwise (#42, #72)"
+```
+
+---
+
+## Task 4: Wire the read merge into `polls.js`
+
+**Files:**
+- Modify: `server/src/routes/polls.js` (three read sites: ~136 GET, ~248 finalize, ~344 unschedule)
+- Test: `server/test/polls.responses.test.js` (new)
+
+**Interfaces:**
+- Consumes: `fetchPollResponses` (Task 2).
+
+- [ ] **Step 1: Write a failing test** — mount the polls router with `fetchPollResponses` mocked to return one `creator` + one `service` response; assert `GET /:did/:rkey` returns both in `responses`. (Mock `resolvePds`/poll `getRecord` for the poll record itself as the existing tests do; the point is that the response list now comes through the helper.)
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement.** Add `import { fetchPollResponses } from '../lib/responseReads.js';`. Replace each of the three inline blocks:
+
+GET `/:did/:rkey` (lines ~136-145) →
+```js
+    const responses = await fetchPollResponses(did, rkey);
+    res.json({ poll: poll.value, uri: poll.uri, cid: poll.cid, responses });
+```
+
+Finalize (lines ~248-253) → replace the `responsesUrl`/fetch/filter/map with:
+```js
+    const pollResponses = await fetchPollResponses(did, rkey);
+```
+(the downstream `participants`/`responseEmails` code consumes `pollResponses` unchanged — the objects still carry `name`/`email`).
+
+Unschedule (lines ~344-349) → same substitution to `pollResponses`.
+
+Delete the now-unused local `RESPONSE_COLLECTION` listRecords URLs if nothing else references them (keep the constant if the poll read still uses it elsewhere — grep first).
+
+- [ ] **Step 4: Run → PASS**, plus the full suite: `cd server && npm test` (every existing polls test stays green — the helper returns the same shape the inline code did, plus `home`/`uri`/`cid`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/routes/polls.js server/test/polls.responses.test.js
+git commit -m "refactor(polls): read responses via the merged creator+service helper (#42)"
+```
+
+---
+
+## Task 5: Docs, env, and the deleted hard constraint
+
+**Files:** `docs/architecture.md`, `CLAUDE.md` (both docs-direct-to-main eligible, but commit on the branch here so the PR is self-describing).
+
+- [ ] Add to `docs/architecture.md`: a "Service identity" subsection — the did:plc account, app-password auth, the service repo as the response store, the read-merge, and the `isServiceConfigured()` fallback. Note #77's resolution (did:plc now; did:web deferred).
+- [ ] In `CLAUDE.md`, **replace** the hard constraint "Anonymous responses require creator's session. If the creator's session expires or is lost, participants can't submit." with: "Responses write to avails' own service repo (`AVAILS_SERVICE_*`); the creator's session is not on the response path. When the service identity is unconfigured, the legacy creator-session path applies (and can 503 if the creator is signed out)."
+- [ ] Add the env vars to the Deployment section: `AVAILS_SERVICE_IDENTIFIER`, `AVAILS_SERVICE_APP_PASSWORD`, optional `AVAILS_SERVICE_PDS`.
+- [ ] Commit: `docs(architecture): document the service-repo response store + activation flag (#42, #77)`.
+
+---
+
+## Task 6: Provisioning + real-PDS smoke (HUMAN-GATED — activation, not merge)
+
+**Not a code task. Gates activation, not merge.** The PR can merge and deploy dark (flag off) before any of this.
+
+- [ ] **Provision (Artem):** create a dedicated ATProto account for avails (bsky.social is simplest). Optionally set the handle to `avails.zhgnv.com` via a `_atproto.avails.zhgnv.com` DNS TXT record (independent of the existing A/CNAME for the web app). Generate an app password in account settings.
+- [ ] **Set Railway env:** `AVAILS_SERVICE_IDENTIFIER` (handle or DID), `AVAILS_SERVICE_APP_PASSWORD` (the app password). Redeploy.
+- [ ] **Smoke (real PDS):** submit a response to a test poll **while signed out as the creator** → expect `201`, no 503. Confirm the response appears on the poll page (read-merge). Confirm the record exists in the service repo (`listRecords` on the service DID) and NOT in the creator's. Edit + delete the response → both succeed via the service session.
+- [ ] **Regression:** an existing (legacy) poll's old responses still render (creator-repo leg of the merge), and editing one still works (creator-session fallback).
+- [ ] Post results to #42; close #77 (did:plc chosen); verify whether #72 and #117 can close (the triage in #125).
+
+---
+
+## Self-Review
+
+- **Spec coverage (#42 Stage 1):** service identity (#77) → Task 1; write path to service repo → Task 3; read merge → Tasks 2+4; hard-constraint deletion → Task 5; activation/smoke → Task 6. Stage 2 (own-PDS authenticated responses) and private-scope responses are explicitly out of scope per #42.
+- **Type consistency:** `fetchPollResponses(creatorDid, rkey) → [{...value, uri, cid, home}]` used identically in Tasks 2 and 4; the service module's `serviceCreateRecord/PutRecord/DeleteRecord/GetRecord` signatures match between Task 1 export and Task 3 import/mock.
+- **YAGNI note (deviation from the design's letter):** the design mentioned extending the poll-index with per-poll response rkeys. This plan does **not** — nothing consumes it in Stage 1 (reads page + filter, which is correct at current scale). The index-driven read (getRecord by stored rkeys, with a paged-scan rebuild fallback) is the documented scale follow-up, filed when the service repo growth makes paging expensive. Flagged rather than silently dropped.
+- **Reversibility:** flag-gated; unset the env vars to revert to legacy behavior with no redeploy of code.

--- a/server/src/lib/responseReads.js
+++ b/server/src/lib/responseReads.js
@@ -1,0 +1,54 @@
+import { isServiceConfigured, getServiceIdentity } from './serviceSession.js';
+
+const RESPONSE_COLLECTION = 'chat.avails.scheduling.response';
+const MAX_PAGES = 20; // 20 * 100 = 2000 records; warn if exceeded rather than truncate silently
+
+async function resolvePds(did) {
+  const res = await fetch(`https://plc.directory/${encodeURIComponent(did)}`);
+  if (!res.ok) throw new Error(`resolve PDS ${did}: ${res.status}`);
+  const doc = await res.json();
+  const svc = doc.service?.find((s) => s.id === '#atproto_pds' || s.type === 'AtprotoPersonalDataServer');
+  return svc?.serviceEndpoint || 'https://bsky.social';
+}
+
+// Page listRecords on `repo`@`pds` for the response collection, keeping records
+// whose pollUri belongs to `rkey`. Public/unauthenticated.
+async function pagedResponses(pds, repo, rkey, home) {
+  const out = [];
+  let cursor;
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const url = `${pds}/xrpc/com.atproto.repo.listRecords?repo=${encodeURIComponent(repo)}&collection=${encodeURIComponent(RESPONSE_COLLECTION)}&limit=100${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ''}`;
+    const res = await fetch(url);
+    if (!res.ok) break;                       // a down repo yields no rows, never throws a read
+    const data = await res.json();
+    for (const r of data.records || []) {
+      if (r.value?.pollUri && r.value.pollUri.endsWith(`/${rkey}`)) {
+        out.push({ ...r.value, uri: r.uri, cid: r.cid, home });
+      }
+    }
+    cursor = data.cursor;
+    if (!cursor) return out;
+  }
+  console.warn(`[responseReads] hit MAX_PAGES for ${repo} poll ${rkey} — response list may be truncated`);
+  return out;
+}
+
+// All responses for a poll, from the creator repo (legacy) + the service repo (new).
+export async function fetchPollResponses(creatorDid, rkey) {
+  const results = [];
+  try {
+    const creatorPds = await resolvePds(creatorDid);
+    results.push(...await pagedResponses(creatorPds, creatorDid, rkey, 'creator'));
+  } catch (err) {
+    console.warn(`[responseReads] creator repo read failed for ${creatorDid}:`, err.message);
+  }
+  if (isServiceConfigured()) {
+    try {
+      const { did, pds } = await getServiceIdentity();
+      results.push(...await pagedResponses(pds, did, rkey, 'service'));
+    } catch (err) {
+      console.warn('[responseReads] service repo read failed:', err.message);
+    }
+  }
+  return results;
+}

--- a/server/src/lib/serviceSession.js
+++ b/server/src/lib/serviceSession.js
@@ -1,0 +1,118 @@
+// avails' own ATProto identity. Writes poll responses to avails' own repo so a
+// response no longer depends on the creator's OAuth session (#42). App-password
+// auth (createSession/refreshSession) — NOT OAuth; this is a headless service
+// credential, not a user grant. Feature-flagged: when the env vars are absent,
+// callers fall back to the legacy creator-session path.
+
+const IDENTIFIER = () => process.env.AVAILS_SERVICE_IDENTIFIER;
+const APP_PASSWORD = () => process.env.AVAILS_SERVICE_APP_PASSWORD;
+const CONFIGURED_PDS = () => process.env.AVAILS_SERVICE_PDS; // optional override
+
+export function isServiceConfigured() {
+  return Boolean(IDENTIFIER() && APP_PASSWORD());
+}
+
+let identity = null;   // { did, pds }
+let tokens = null;     // { accessJwt, refreshJwt }
+
+async function resolvePdsForDid(did) {
+  const res = await fetch(`https://plc.directory/${encodeURIComponent(did)}`);
+  if (!res.ok) throw new Error(`resolve PDS for ${did}: ${res.status}`);
+  const doc = await res.json();
+  const svc = doc.service?.find((s) => s.id === '#atproto_pds' || s.type === 'AtprotoPersonalDataServer');
+  return svc?.serviceEndpoint || 'https://bsky.social';
+}
+
+// The host we call createSession against IS the account's PDS. Prefer an explicit
+// AVAILS_SERVICE_PDS; else default to bsky.social for login, then trust the DID's
+// resolved PDS for reads/writes.
+function loginHost() {
+  return CONFIGURED_PDS() || 'https://bsky.social';
+}
+
+async function login() {
+  if (!isServiceConfigured()) throw new Error('service identity not configured');
+  const res = await fetch(`${loginHost()}/xrpc/com.atproto.server.createSession`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ identifier: IDENTIFIER(), password: APP_PASSWORD() }),
+  });
+  if (!res.ok) throw new Error(`service login failed: ${res.status} ${await res.text().catch(() => '')}`);
+  const data = await res.json();
+  tokens = { accessJwt: data.accessJwt, refreshJwt: data.refreshJwt };
+  identity = { did: data.did, pds: CONFIGURED_PDS() || (await resolvePdsForDid(data.did)) };
+  return identity;
+}
+
+export async function getServiceIdentity() {
+  if (identity) return identity;
+  return login();
+}
+
+async function refresh() {
+  const res = await fetch(`${loginHost()}/xrpc/com.atproto.server.refreshSession`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${tokens.refreshJwt}` },
+  });
+  if (!res.ok) { await login(); return; }        // refresh dead → full re-login
+  const data = await res.json();
+  tokens = { accessJwt: data.accessJwt, refreshJwt: data.refreshJwt };
+}
+
+// Authenticated XRPC POST against the service PDS, refreshing+retrying once on an
+// expired/invalid token.
+async function authedXrpc(method, body, { retry = true } = {}) {
+  const id = await getServiceIdentity();
+  if (!tokens) await login();
+  const doCall = () => fetch(`${id.pds}/xrpc/${method}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${tokens.accessJwt}` },
+    body: JSON.stringify(body),
+  });
+  let res = await doCall();
+  if (!res.ok && retry) {
+    const text = await res.text().catch(() => '');
+    if (res.status === 400 || res.status === 401) {
+      if (/ExpiredToken|InvalidToken|AuthenticationRequired/i.test(text)) {
+        await refresh();
+        res = await doCall();
+      } else {
+        throw new Error(`${method} failed (${res.status}): ${text}`);
+      }
+    } else {
+      throw new Error(`${method} failed (${res.status}): ${text}`);
+    }
+  }
+  if (!res.ok) throw new Error(`${method} failed (${res.status}): ${await res.text().catch(() => '')}`);
+  return res.json();
+}
+
+export async function serviceCreateRecord(collection, record) {
+  const { did } = await getServiceIdentity();
+  return authedXrpc('com.atproto.repo.createRecord', { repo: did, collection, record });
+}
+
+export async function servicePutRecord(collection, rkey, record) {
+  const { did } = await getServiceIdentity();
+  return authedXrpc('com.atproto.repo.putRecord', { repo: did, collection, rkey, record });
+}
+
+export async function serviceDeleteRecord(collection, rkey) {
+  const { did } = await getServiceIdentity();
+  await authedXrpc('com.atproto.repo.deleteRecord', { repo: did, collection, rkey });
+}
+
+// Public read against the service repo — no auth needed, but we reuse the resolved
+// PDS. Returns null on 404 so callers can disambiguate a service record from a
+// legacy creator-repo one.
+export async function serviceGetRecord(collection, rkey) {
+  const { did, pds } = await getServiceIdentity();
+  const url = `${pds}/xrpc/com.atproto.repo.getRecord?repo=${encodeURIComponent(did)}&collection=${encodeURIComponent(collection)}&rkey=${encodeURIComponent(rkey)}`;
+  const res = await fetch(url);
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`getRecord failed (${res.status})`);
+  return res.json();
+}
+
+// Test-only: reset cached identity/tokens.
+export function __resetForTest() { identity = null; tokens = null; }

--- a/server/src/routes/polls.js
+++ b/server/src/routes/polls.js
@@ -5,12 +5,11 @@ import { indexPoll, updatePollStatus, removePoll, listByCommunity } from '../lib
 import { generateIcs } from '../lib/ical.js';
 import { sendEmail } from '../lib/email.js';
 import { deleteOpenMeetEvent } from './openmeet.js';
-import { sessions } from '../lib/sessionStore.js';
+import { fetchPollResponses } from '../lib/responseReads.js';
 
 const router = Router();
 
 const POLL_COLLECTION = 'chat.avails.scheduling.poll';
-const RESPONSE_COLLECTION = 'chat.avails.scheduling.response';
 
 // Fetch with timeout — prevents hanging on slow PDS responses
 function fetchWithTimeout(url, options = {}, timeoutMs = 10000) {
@@ -132,17 +131,8 @@ router.get('/:did/:rkey', async (req, res, next) => {
     }
     const poll = await pollRes.json();
 
-    // Fetch response records stored in the creator's PDS
-    const responsesUrl = `${pds}/xrpc/com.atproto.repo.listRecords?repo=${encodeURIComponent(did)}&collection=${encodeURIComponent(RESPONSE_COLLECTION)}&limit=100`;
-    const responsesRes = await fetchWithTimeout(responsesUrl);
-    let responses = [];
-    if (responsesRes.ok) {
-      const data = await responsesRes.json();
-      // Filter to only responses belonging to this poll, unwrap value
-      responses = (data.records || [])
-        .filter((r) => r.value?.pollUri && r.value.pollUri.includes(`/${rkey}`))
-        .map((r) => ({ ...r.value, uri: r.uri, cid: r.cid }));
-    }
+    // Response records: creator repo (legacy) + service repo (new), merged (#42).
+    const responses = await fetchPollResponses(did, rkey);
 
     res.json({ poll: poll.value, uri: poll.uri, cid: poll.cid, responses });
   } catch (err) {
@@ -243,14 +233,9 @@ router.put('/:did/:rkey/finalize', requireAuth, async (req, res, next) => {
 
     updatePollStatus(did, rkey, 'finalized');
 
-    // Fetch responses for participant names and emails
+    // Fetch responses for participant names and emails (creator + service, #42)
     const pollUrl = `${process.env.CLIENT_URL || 'http://localhost:5173'}/poll/${did}/${rkey}`;
-    const responsesUrl = `${pds}/xrpc/com.atproto.repo.listRecords?repo=${encodeURIComponent(did)}&collection=${encodeURIComponent(RESPONSE_COLLECTION)}&limit=100`;
-    const responsesRes = await fetchWithTimeout(responsesUrl);
-    const responseData = responsesRes.ok ? await responsesRes.json() : { records: [] };
-    const pollResponses = (responseData.records || [])
-      .filter((r) => r.value?.pollUri && r.value.pollUri.includes(`/${rkey}`))
-      .map((r) => r.value);
+    const pollResponses = await fetchPollResponses(did, rkey);
 
     const participants = pollResponses.filter((r) => r.name).map((r) => r.name);
     const icsContent = generateIcs({
@@ -341,12 +326,7 @@ router.delete('/:did/:rkey/finalize', requireAuth, async (req, res, next) => {
 
     // Best-effort: send cancellation emails with METHOD:CANCEL .ics
     const pollUrl = `${process.env.CLIENT_URL || 'http://localhost:5173'}/poll/${did}/${rkey}`;
-    const responsesUrl = `${pds}/xrpc/com.atproto.repo.listRecords?repo=${encodeURIComponent(did)}&collection=${encodeURIComponent(RESPONSE_COLLECTION)}&limit=100`;
-    const responsesRes = await fetchWithTimeout(responsesUrl);
-    const responseData = responsesRes.ok ? await responsesRes.json() : { records: [] };
-    const pollResponses = (responseData.records || [])
-      .filter((r) => r.value?.pollUri && r.value.pollUri.includes(`/${rkey}`))
-      .map((r) => r.value);
+    const pollResponses = await fetchPollResponses(did, rkey);
 
     const participants = pollResponses.filter((r) => r.name).map((r) => r.name);
     const emailList = [...new Set(pollResponses.filter((r) => r.email).map((r) => r.email))];

--- a/server/src/routes/responses.js
+++ b/server/src/routes/responses.js
@@ -4,11 +4,19 @@ import { getClient } from './auth.js';
 import { validateResponseCreate } from '../middleware/validate.js';
 import { incrementResponseCount } from '../lib/pollIndex.js';
 import { sendEmail } from '../lib/email.js';
+import {
+  isServiceConfigured, serviceCreateRecord, servicePutRecord, serviceDeleteRecord, serviceGetRecord,
+} from '../lib/serviceSession.js';
 
 const router = Router();
 
 const RESPONSE_COLLECTION = 'chat.avails.scheduling.response';
 const POLL_COLLECTION = 'chat.avails.scheduling.poll';
+
+// Legacy-path 503: only reachable when the service identity is unconfigured (or
+// when editing a pre-migration record that lives in the creator's repo) AND the
+// creator is signed out. The service path never 503s.
+const UNAVAILABLE_MSG = 'This poll is temporarily unavailable. The poll creator needs to sign back in at avails.zhgnv.com for responses to work. Please try again in a few minutes.';
 
 // Fetch with timeout — prevents hanging on slow PDS responses
 function fetchWithTimeout(url, options = {}, timeoutMs = 10000) {
@@ -66,19 +74,13 @@ async function xrpcCall(oauthSession, method, body) {
   return response.json();
 }
 
-// POST /api/polls/:did/:rkey/responses — submit availability response
-// Anonymous participants write to the CREATOR's PDS using the creator's stored session.
+// POST /api/polls/:did/:rkey/responses — submit availability response.
+// New responses are written to avails' own service repo (#42) so they no longer
+// depend on the creator being signed in. When the service identity is
+// unconfigured, fall back to the legacy creator-PDS write.
 router.post('/:did/:rkey/responses', validateResponseCreate, async (req, res, next) => {
   try {
     const { did, rkey } = req.params;
-
-    // Find creator's OAuth session — required for writing to their PDS
-    const creatorSession = await findOauthSessionByDid(did);
-    if (!creatorSession) {
-      return res.status(503).json({
-        error: 'This poll is temporarily unavailable. The poll creator needs to sign back in at avails.zhgnv.com for responses to work. Please try again in a few minutes.',
-      });
-    }
 
     const pollUri = `at://${did}/${POLL_COLLECTION}/${rkey}`;
     const record = {
@@ -88,15 +90,20 @@ router.post('/:did/:rkey/responses', validateResponseCreate, async (req, res, ne
       createdAt: new Date().toISOString(),
     };
 
-    const createResult = await xrpcCall(creatorSession, 'com.atproto.repo.createRecord', {
-      repo: did,
-      collection: RESPONSE_COLLECTION,
-      record,
-    });
-
-    // Extract the rkey of the newly created response record
-    // AT URI format: at://did/collection/rkey
-    const createdResponseRkey = createResult?.uri?.split('/').pop() || null;
+    let createdResponseRkey = null;
+    if (isServiceConfigured()) {
+      const createResult = await serviceCreateRecord(RESPONSE_COLLECTION, record);
+      createdResponseRkey = createResult?.uri?.split('/').pop() || null;
+    } else {
+      const creatorSession = await findOauthSessionByDid(did);
+      if (!creatorSession) return res.status(503).json({ error: UNAVAILABLE_MSG });
+      const createResult = await xrpcCall(creatorSession, 'com.atproto.repo.createRecord', {
+        repo: did,
+        collection: RESPONSE_COLLECTION,
+        record,
+      });
+      createdResponseRkey = createResult?.uri?.split('/').pop() || null;
+    }
 
     // Increment response count in index and check notifyAfter threshold
     const newCount = incrementResponseCount(did, rkey);
@@ -129,17 +136,13 @@ router.post('/:did/:rkey/responses', validateResponseCreate, async (req, res, ne
   }
 });
 
-// PUT /api/polls/:did/:rkey/responses/:responseRkey — update an existing response
+// PUT /api/polls/:did/:rkey/responses/:responseRkey — update an existing response.
+// A record created since #42 lives in the service repo; a pre-migration record
+// lives in the creator's repo. Disambiguate with a service getRecord, then route
+// the write to the repo that actually holds it.
 router.put('/:did/:rkey/responses/:responseRkey', validateResponseCreate, async (req, res, next) => {
   try {
     const { did, rkey, responseRkey } = req.params;
-
-    const creatorSession = await findOauthSessionByDid(did);
-    if (!creatorSession) {
-      return res.status(503).json({
-        error: 'This poll is temporarily unavailable. The poll creator needs to sign back in at avails.zhgnv.com for responses to work. Please try again in a few minutes.',
-      });
-    }
 
     const pollUri = `at://${did}/${POLL_COLLECTION}/${rkey}`;
     const record = {
@@ -149,12 +152,18 @@ router.put('/:did/:rkey/responses/:responseRkey', validateResponseCreate, async 
       createdAt: new Date().toISOString(),
     };
 
-    await xrpcCall(creatorSession, 'com.atproto.repo.putRecord', {
-      repo: did,
-      collection: RESPONSE_COLLECTION,
-      rkey: responseRkey,
-      record,
-    });
+    if (isServiceConfigured() && await serviceGetRecord(RESPONSE_COLLECTION, responseRkey)) {
+      await servicePutRecord(RESPONSE_COLLECTION, responseRkey, record);
+    } else {
+      const creatorSession = await findOauthSessionByDid(did);
+      if (!creatorSession) return res.status(503).json({ error: UNAVAILABLE_MSG });
+      await xrpcCall(creatorSession, 'com.atproto.repo.putRecord', {
+        repo: did,
+        collection: RESPONSE_COLLECTION,
+        rkey: responseRkey,
+        record,
+      });
+    }
 
     res.json({ ok: true });
   } catch (err) {
@@ -162,32 +171,33 @@ router.put('/:did/:rkey/responses/:responseRkey', validateResponseCreate, async 
   }
 });
 
-// DELETE /:did/:rkey/responses/:responseRkey — delete a response
+// DELETE /:did/:rkey/responses/:responseRkey — delete a response. Same service-vs
+// -legacy disambiguation as PUT.
 router.delete('/:did/:rkey/responses/:responseRkey', async (req, res, next) => {
   try {
     const { did, responseRkey } = req.params;
 
-    const creatorSession = await findOauthSessionByDid(did);
-    if (!creatorSession) {
-      return res.status(503).json({ error: 'This poll is temporarily unavailable. The poll creator needs to sign back in at avails.zhgnv.com for responses to work. Please try again in a few minutes.' });
-    }
-
-    const deleteResult = await creatorSession.fetchHandler(
-      `/xrpc/com.atproto.repo.deleteRecord`,
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          repo: did,
-          collection: RESPONSE_COLLECTION,
-          rkey: responseRkey,
-        }),
+    if (isServiceConfigured() && await serviceGetRecord(RESPONSE_COLLECTION, responseRkey)) {
+      await serviceDeleteRecord(RESPONSE_COLLECTION, responseRkey);
+    } else {
+      const creatorSession = await findOauthSessionByDid(did);
+      if (!creatorSession) return res.status(503).json({ error: UNAVAILABLE_MSG });
+      const deleteResult = await creatorSession.fetchHandler(
+        `/xrpc/com.atproto.repo.deleteRecord`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            repo: did,
+            collection: RESPONSE_COLLECTION,
+            rkey: responseRkey,
+          }),
+        }
+      );
+      if (!deleteResult.ok) {
+        const text = await deleteResult.text();
+        throw new Error(`Failed to delete response: ${deleteResult.status} ${text}`);
       }
-    );
-
-    if (!deleteResult.ok) {
-      const text = await deleteResult.text();
-      throw new Error(`Failed to delete response: ${deleteResult.status} ${text}`);
     }
 
     res.json({ ok: true });

--- a/server/test/polls.responses.test.js
+++ b/server/test/polls.responses.test.js
@@ -1,0 +1,56 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+
+// The read path should get its responses from the merged creator+service helper,
+// not from an inline creator-only listRecords.
+mock.module('../src/lib/responseReads.js', {
+  namedExports: {
+    fetchPollResponses: async () => ([
+      { name: 'LegacyPerson', slots: ['2026-07-21T09:00'], uri: 'at://c/r/1', cid: 'c1', home: 'creator' },
+      { name: 'ServicePerson', slots: ['2026-07-21T09:00'], uri: 'at://s/r/2', cid: 's2', home: 'service' },
+    ]),
+  },
+});
+
+const originalFetch = globalThis.fetch;
+globalThis.fetch = async (url) => {
+  const u = String(url);
+  if (u.includes('plc.directory')) return { ok: true, json: async () => ({ service: [{ id: '#atproto_pds', serviceEndpoint: 'https://creator.pds' }] }) };
+  if (u.includes('getRecord')) return { ok: true, json: async () => ({ value: { title: 'Test Poll', status: 'open' }, uri: 'at://did:plc:creator/p/poll1', cid: 'pcid' }) };
+  // Legacy inline read (pre-refactor) would hit this and get nothing → RED until the route uses the helper.
+  if (u.includes('listRecords')) return { ok: true, json: async () => ({ records: [] }) };
+  return originalFetch(url);
+};
+
+const { default: pollRoutes } = await import('../src/routes/polls.js');
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/polls', pollRoutes);
+  return app;
+}
+
+async function request(app, method, path) {
+  const { once } = await import('node:events');
+  const server = app.listen(0);
+  await once(server, 'listening');
+  const port = server.address().port;
+  try {
+    const res = await originalFetch(`http://localhost:${port}${path}`, { method });
+    return { status: res.status, body: await res.json().catch(() => null) };
+  } finally {
+    server.close();
+  }
+}
+
+describe('GET /:did/:rkey merges creator + service responses', () => {
+  it('returns both legacy and service responses from the merged helper', async () => {
+    const app = createApp();
+    const res = await request(app, 'GET', '/api/polls/did:plc:creator/poll1');
+    assert.equal(res.status, 200);
+    assert.equal(res.body.responses.length, 2);
+    assert.deepEqual(res.body.responses.map((r) => r.home).sort(), ['creator', 'service']);
+  });
+});

--- a/server/test/responseReads.test.js
+++ b/server/test/responseReads.test.js
@@ -1,0 +1,55 @@
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+const originalFetch = globalThis.fetch;
+const originalEnv = { ...process.env };
+beforeEach(() => { process.env = { ...originalEnv }; globalThis.fetch = originalFetch; });
+
+test('merges creator (legacy) + service responses, tags home, filters by poll, pages', async () => {
+  process.env.AVAILS_SERVICE_IDENTIFIER = 'avails.zhgnv.com';
+  process.env.AVAILS_SERVICE_APP_PASSWORD = 'pw';
+  process.env.AVAILS_SERVICE_PDS = 'https://svc.pds';
+  const CREATOR = 'did:plc:creator';
+  globalThis.fetch = async (url) => {
+    const u = String(url);
+    if (u.includes('plc.directory')) return { ok: true, json: async () => ({ service: [{ id: '#atproto_pds', serviceEndpoint: 'https://creator.pds' }] }) };
+    if (u.includes('createSession')) return { ok: true, json: async () => ({ accessJwt: 'A', refreshJwt: 'R', did: 'did:plc:svc' }) };
+    if (u.includes('creator.pds') && u.includes('listRecords')) {
+      return { ok: true, json: async () => ({ records: [
+        { uri: 'at://c/r/leg1', cid: 'c1', value: { pollUri: `at://${CREATOR}/p/poll1`, name: 'Legacy' } },
+        { uri: 'at://c/r/other', cid: 'c9', value: { pollUri: `at://${CREATOR}/p/OTHER`, name: 'Nope' } },
+      ] }) };
+    }
+    if (u.includes('svc.pds') && u.includes('listRecords')) {
+      if (!u.includes('cursor=')) return { ok: true, json: async () => ({ cursor: 'pg2', records: [
+        { uri: 'at://s/r/s1', cid: 's1', value: { pollUri: `at://${CREATOR}/p/poll1`, name: 'New1' } },
+      ] }) };
+      return { ok: true, json: async () => ({ records: [
+        { uri: 'at://s/r/s2', cid: 's2', value: { pollUri: `at://${CREATOR}/p/poll1`, name: 'New2' } },
+      ] }) };
+    }
+    throw new Error(`unexpected ${u}`);
+  };
+  const { fetchPollResponses } = await import('../src/lib/responseReads.js?case=merge');
+  const out = await fetchPollResponses(CREATOR, 'poll1');
+  const names = out.map((r) => r.name).sort();
+  assert.deepEqual(names, ['Legacy', 'New1', 'New2']);
+  assert.equal(out.find((r) => r.name === 'Legacy').home, 'creator');
+  assert.equal(out.find((r) => r.name === 'New2').home, 'service');
+});
+
+test('when service not configured, returns creator responses only', async () => {
+  delete process.env.AVAILS_SERVICE_IDENTIFIER;
+  delete process.env.AVAILS_SERVICE_APP_PASSWORD;
+  globalThis.fetch = async (url) => {
+    const u = String(url);
+    if (u.includes('plc.directory')) return { ok: true, json: async () => ({ service: [{ id: '#atproto_pds', serviceEndpoint: 'https://creator.pds' }] }) };
+    if (u.includes('listRecords')) return { ok: true, json: async () => ({ records: [
+      { uri: 'at://c/r/1', cid: 'c1', value: { pollUri: 'at://did:plc:creator/p/poll1', name: 'Only' } },
+    ] }) };
+    throw new Error(`unexpected ${u}`);
+  };
+  const { fetchPollResponses } = await import('../src/lib/responseReads.js?case=nocfg');
+  const out = await fetchPollResponses('did:plc:creator', 'poll1');
+  assert.deepEqual(out.map((r) => r.name), ['Only']);
+});

--- a/server/test/responses.test.js
+++ b/server/test/responses.test.js
@@ -6,7 +6,7 @@
  * mocking the session store and PDS layer to isolate route logic.
  */
 
-import { describe, it, beforeEach, mock } from 'node:test';
+import { describe, it, beforeEach, afterEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import express from 'express';
 
@@ -42,6 +42,21 @@ mock.module('../src/lib/pollIndex.js', {
 mock.module('../src/lib/email.js', {
   namedExports: {
     sendEmail: async () => {},
+  },
+});
+
+// Mock the service identity. isServiceConfigured is driven by an env flag so the
+// legacy describes (flag unset) exercise the creator-session path unchanged, and
+// the service describe (flag 'on') exercises the service-repo path.
+let serviceCalls = [];
+let serviceHas = new Set(); // rkeys the service repo "contains" (getRecord disambiguation)
+mock.module('../src/lib/serviceSession.js', {
+  namedExports: {
+    isServiceConfigured: () => process.env.AVAILS_SERVICE_IDENTIFIER === 'on',
+    serviceCreateRecord: async (collection, record) => { serviceCalls.push({ op: 'create', collection, record }); return { uri: 'at://did:plc:svc/chat.avails.scheduling.response/svc123' }; },
+    servicePutRecord: async (collection, rkey, record) => { serviceCalls.push({ op: 'put', rkey, record }); },
+    serviceDeleteRecord: async (collection, rkey) => { serviceCalls.push({ op: 'delete', rkey }); },
+    serviceGetRecord: async (collection, rkey) => (serviceHas.has(rkey) ? { uri: `at://did:plc:svc/c/${rkey}`, value: {} } : null),
   },
 });
 
@@ -237,7 +252,8 @@ describe('PUT /api/polls/:did/:rkey/responses/:responseRkey', () => {
     assert.equal(lastXrpcCall, null);
   });
 
-  it('returns 503 when creator session is missing', async () => {
+  it('returns 503 when creator session is missing (legacy path only)', async () => {
+    delete process.env.AVAILS_SERVICE_IDENTIFIER; // legacy path
     mockSessions.clear(); // No sessions at all
     const app = createApp();
     const res = await request(app, 'PUT', path, {
@@ -246,5 +262,61 @@ describe('PUT /api/polls/:did/:rkey/responses/:responseRkey', () => {
     });
     assert.equal(res.status, 503);
     assert.ok(res.body.error.includes('unavailable'));
+  });
+});
+
+describe('service-configured write path', () => {
+  const did = 'did:plc:testcreator';
+  const rkey = 'poll123';
+  const path = `/api/polls/${did}/${rkey}/responses`;
+
+  beforeEach(() => {
+    process.env.AVAILS_SERVICE_IDENTIFIER = 'on';
+    mockSessions.clear();
+    lastXrpcCall = null;
+    serviceCalls = [];
+    serviceHas = new Set();
+  });
+  afterEach(() => { delete process.env.AVAILS_SERVICE_IDENTIFIER; });
+
+  it('POST writes to the service repo, not the creator session, and never 503s when creator is signed out', async () => {
+    // creator NOT signed in (mockSessions cleared) — legacy path would 503 here
+    const app = createApp();
+    const res = await request(app, 'POST', path, { name: 'Bea', slots: ['2026-07-21T09:00'] });
+    assert.equal(res.status, 201);
+    assert.equal(serviceCalls.length, 1);
+    assert.equal(serviceCalls[0].op, 'create');
+    assert.equal(serviceCalls[0].record.name, 'Bea');
+    assert.equal(serviceCalls[0].record.pollUri.includes(rkey), true);
+    assert.equal(res.body.responseRkey, 'svc123');
+    assert.equal(lastXrpcCall, null); // creator session NOT used
+  });
+
+  it('PUT of a service-repo record uses the service session', async () => {
+    serviceHas.add('resp456');
+    const app = createApp();
+    const res = await request(app, 'PUT', `/api/polls/${did}/${rkey}/responses/resp456`, { name: 'Bea', slots: ['2026-07-21T09:00'] });
+    assert.equal(res.status, 200);
+    assert.equal(serviceCalls.at(-1).op, 'put');
+    assert.equal(serviceCalls.at(-1).rkey, 'resp456');
+  });
+
+  it('PUT of a legacy (creator-repo) record falls back to the creator session', async () => {
+    // serviceHas empty → serviceGetRecord returns null → legacy path
+    mockSessions.set('creator-session', { did, oauthSession: { fetchHandler: mockFetchHandler } });
+    const app = createApp();
+    const res = await request(app, 'PUT', `/api/polls/${did}/${rkey}/responses/legacyRK`, { name: 'Bea', slots: ['2026-07-21T09:00'] });
+    assert.equal(res.status, 200);
+    assert.equal(serviceCalls.filter((c) => c.op === 'put').length, 0); // service put NOT used
+    assert.ok(lastXrpcCall); // creator session WAS used
+  });
+
+  it('DELETE of a service-repo record uses the service session', async () => {
+    serviceHas.add('resp456');
+    const app = createApp();
+    const res = await request(app, 'DELETE', `/api/polls/${did}/${rkey}/responses/resp456`);
+    assert.equal(res.status, 200);
+    assert.equal(serviceCalls.at(-1).op, 'delete');
+    assert.equal(serviceCalls.at(-1).rkey, 'resp456');
   });
 });

--- a/server/test/serviceSession.test.js
+++ b/server/test/serviceSession.test.js
@@ -1,0 +1,85 @@
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+// serviceSession caches identity + tokens at module scope; import fresh per concern
+// via a query-string cache-bust so each test starts clean.
+const originalFetch = globalThis.fetch;
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env = { ...originalEnv };
+  globalThis.fetch = originalFetch;
+});
+
+test('isServiceConfigured reflects both env vars', async () => {
+  const mod = await import('../src/lib/serviceSession.js?case=cfg');
+  delete process.env.AVAILS_SERVICE_IDENTIFIER;
+  delete process.env.AVAILS_SERVICE_APP_PASSWORD;
+  assert.equal(mod.isServiceConfigured(), false);
+  process.env.AVAILS_SERVICE_IDENTIFIER = 'avails.zhgnv.com';
+  process.env.AVAILS_SERVICE_APP_PASSWORD = 'app-pw';
+  assert.equal(mod.isServiceConfigured(), true);
+});
+
+test('serviceCreateRecord logs in once, then writes with the access token', async () => {
+  process.env.AVAILS_SERVICE_IDENTIFIER = 'avails.zhgnv.com';
+  process.env.AVAILS_SERVICE_APP_PASSWORD = 'app-pw';
+  process.env.AVAILS_SERVICE_PDS = 'https://pds.test';
+  const calls = [];
+  globalThis.fetch = async (url, opts = {}) => {
+    const u = String(url); calls.push(u);
+    if (u.includes('com.atproto.server.createSession')) {
+      return { ok: true, json: async () => ({ accessJwt: 'A1', refreshJwt: 'R1', did: 'did:plc:svc' }) };
+    }
+    if (u.includes('com.atproto.repo.createRecord')) {
+      assert.equal(opts.headers.Authorization, 'Bearer A1');
+      return { ok: true, json: async () => ({ uri: 'at://did:plc:svc/c/xyz', cid: 'cid1' }) };
+    }
+    throw new Error(`unexpected ${u}`);
+  };
+  const mod = await import('../src/lib/serviceSession.js?case=create');
+  const r = await mod.serviceCreateRecord('chat.avails.scheduling.response', { pollUri: 'at://x/y/z' });
+  assert.equal(r.uri, 'at://did:plc:svc/c/xyz');
+  assert.equal(calls.filter((c) => c.includes('createSession')).length, 1);
+});
+
+test('an expired access token triggers refresh then retry', async () => {
+  process.env.AVAILS_SERVICE_IDENTIFIER = 'avails.zhgnv.com';
+  process.env.AVAILS_SERVICE_APP_PASSWORD = 'app-pw';
+  process.env.AVAILS_SERVICE_PDS = 'https://pds.test';
+  let wrote = 0;
+  globalThis.fetch = async (url, opts = {}) => {
+    const u = String(url);
+    if (u.includes('createSession')) return { ok: true, json: async () => ({ accessJwt: 'A1', refreshJwt: 'R1', did: 'did:plc:svc' }) };
+    if (u.includes('refreshSession')) {
+      assert.equal(opts.headers.Authorization, 'Bearer R1');
+      return { ok: true, json: async () => ({ accessJwt: 'A2', refreshJwt: 'R2', did: 'did:plc:svc' }) };
+    }
+    if (u.includes('createRecord')) {
+      if (opts.headers.Authorization === 'Bearer A1') {
+        return { ok: false, status: 400, json: async () => ({ error: 'ExpiredToken' }), text: async () => 'ExpiredToken' };
+      }
+      assert.equal(opts.headers.Authorization, 'Bearer A2'); wrote++;
+      return { ok: true, json: async () => ({ uri: 'at://did:plc:svc/c/ok', cid: 'c' }) };
+    }
+    throw new Error(`unexpected ${u}`);
+  };
+  const mod = await import('../src/lib/serviceSession.js?case=refresh');
+  const r = await mod.serviceCreateRecord('c', { pollUri: 'p' });
+  assert.equal(r.uri, 'at://did:plc:svc/c/ok');
+  assert.equal(wrote, 1);
+});
+
+test('serviceGetRecord returns null on 404', async () => {
+  process.env.AVAILS_SERVICE_IDENTIFIER = 'avails.zhgnv.com';
+  process.env.AVAILS_SERVICE_APP_PASSWORD = 'app-pw';
+  process.env.AVAILS_SERVICE_PDS = 'https://pds.test';
+  globalThis.fetch = async (url) => {
+    const u = String(url);
+    if (u.includes('createSession')) return { ok: true, json: async () => ({ accessJwt: 'A1', refreshJwt: 'R1', did: 'did:plc:svc' }) };
+    if (u.includes('getRecord')) return { ok: false, status: 404, text: async () => 'not found' };
+    throw new Error(`unexpected ${u}`);
+  };
+  const mod = await import('../src/lib/serviceSession.js?case=get404');
+  assert.equal(await mod.serviceGetRecord('c', 'missing'), null);
+});


### PR DESCRIPTION
Stage 1 of #42: give avails its own ATProto service identity and write poll responses to **its own repo**, so a response no longer depends on the creator being signed in. Deletes the 503 failure class (#72, #117) and the "anonymous responses require creator's session" hard constraint.

Resolves #42 (Stage 1). Answers #77 (did:plc service identity now; did:web deferred). Design: the #42 design-resolution comment (2026-07-18).

## Ships dark — activation is separate from merge

The entire new path is gated behind `isServiceConfigured()` (true iff `AVAILS_SERVICE_IDENTIFIER` + `AVAILS_SERVICE_APP_PASSWORD` are set). **With the env vars unset, every route behaves byte-for-byte as today** — so merging and deploying this changes nothing. Setting the two vars is the activation switch, reversible by unsetting them.

## What changed

- **`server/src/lib/serviceSession.js`** (new) — app-password login (`createSession`), refresh-on-expiry with re-login fallback, authed `createRecord`/`putRecord`/`deleteRecord`/`getRecord`. Raw XRPC (no `@atproto/api` dep).
- **`server/src/lib/responseReads.js`** (new) — `fetchPollResponses(creatorDid, rkey)` merges creator repo (legacy) + service repo (new), fully cursor-paged, filtered by `pollUri`, each tagged `home: 'creator' | 'service'`. Public/unauthenticated; a read never depends on the service login.
- **`server/src/routes/responses.js`** — POST/PUT/DELETE branch on the flag. Service writes when configured; legacy creator-session fallback otherwise. PUT/DELETE disambiguate a service record from a legacy one via a service `getRecord`.
- **`server/src/routes/polls.js`** — the three response-read sites (GET, finalize, unschedule) now go through the merged helper. Dropped the now-dead `RESPONSE_COLLECTION` constant and `sessions` import.
- **Docs** — `architecture.md` gains a Service-identity section, #42 debt marked resolved; `CLAUDE.md` hard constraint replaced, env vars documented.

## Tests

137/137 green (`cd server && npm test`). New coverage: service-session login/refresh/404; read-merge with cursor paging + `home` tagging + not-configured fallback; write-path branching (service write, no-503-when-signed-out, PUT/DELETE service-vs-legacy routing); GET read-merge.

## Not in this PR

- **Real-PDS smoke + activation** — gated on provisioning the service account (create the account, set the two env vars). Unit tests mock the ATProto layer, so they prove the plumbing, not a live `createSession` round-trip.
- **Stage 2** (authenticated respondents write to their own PDS) and **private-scope responses** — out of scope per #42.
