### PR TITLE
Publish avails polls to the community feed (opt-in, membership-gated)

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -12,6 +12,7 @@ import availabilityRoutes from './routes/availability.js';
 import communityRoutes from './routes/communities.js';
 import openmeetRoutes from './routes/openmeet.js';
 import { startPersistence, markDirty, saveNow } from './lib/persistence.js';
+import { backfillCommunityFeedPublished } from './lib/pollIndex.js';
 import { restoreOAuthSessions, sessions } from './lib/sessionStore.js';
 import { spaFallback } from './middleware/spaFallback.js';
 import mcpOauthRoutes from './mcp/oauth.js';
@@ -180,6 +181,12 @@ process.on('unhandledRejection', (err) => {
 
 async function start() {
   await startPersistence();
+  // One-time grandfather of open polls into the community feed (#5 sub-project F),
+  // after the index is restored and before serving. Idempotent across restarts.
+  const grandfathered = backfillCommunityFeedPublished();
+  if (grandfathered > 0) {
+    console.log(`Community feed: grandfathered ${grandfathered} open poll(s) as published`);
+  }
   app.listen(PORT, async () => {
     console.log(`Avails server listening on port ${PORT}`);
     try {

--- a/server/src/lib/pollIndex.js
+++ b/server/src/lib/pollIndex.js
@@ -1,5 +1,5 @@
 // Poll index for community-based discovery.
-// key: `${did}/${rkey}` → { did, rkey, title, community, status, responseCount, createdAt }
+// key: `${did}/${rkey}` → { did, rkey, title, community, status, responseCount, createdAt, publishedAt }
 // Persisted to Railway volume via persistence.js.
 
 import { registerStore, markDirty } from './persistence.js';
@@ -9,6 +9,7 @@ registerStore('poll-index', polls);
 
 export function indexPoll(did, rkey, poll) {
   const key = `${did}/${rkey}`;
+  const existing = polls.get(key);
   polls.set(key, {
     did,
     rkey,
@@ -17,6 +18,9 @@ export function indexPoll(did, rkey, poll) {
     status: poll.status || 'open',
     responseCount: poll.responseCount || 0,
     createdAt: poll.createdAt || new Date().toISOString(),
+    // Community-feed publish marker (#5 sub-project F). Presence = published.
+    // Preserved across re-index (e.g. a title edit) so publishing survives.
+    publishedAt: poll.publishedAt ?? existing?.publishedAt ?? null,
   });
   markDirty('poll-index');
 }
@@ -26,6 +30,16 @@ export function updatePollStatus(did, rkey, status) {
   const entry = polls.get(key);
   if (entry) {
     polls.set(key, { ...entry, status });
+    markDirty('poll-index');
+  }
+}
+
+// Set (ISO string) or clear (null) a poll's community-feed publish marker.
+export function updatePollPublished(did, rkey, publishedAt) {
+  const key = `${did}/${rkey}`;
+  const entry = polls.get(key);
+  if (entry) {
+    polls.set(key, { ...entry, publishedAt });
     markDirty('poll-index');
   }
 }
@@ -45,10 +59,34 @@ export function removePoll(did, rkey) {
   markDirty('poll-index');
 }
 
-export function listByCommunity(community, status = 'open') {
+// One-time grandfather for the community-feed opt-in (#5 sub-project F). Polls
+// indexed before the feature have no `publishedAt` field (they load from a
+// pre-migration snapshot as `undefined`); keep the currently-open ones visible
+// when the feed becomes opt-in by treating them as published. Idempotent by
+// construction: only entries whose field is strictly `undefined` are touched, so
+// once the store has been saved (every entry then a string or null) reruns are
+// no-ops — and an explicitly unpublished poll (null) is never re-grandfathered.
+// The server cannot write other creators' PDS records, so this is index-only;
+// the record's communityFeedPublishedAt stays authoritative from here on.
+// Returns the number of polls newly marked published.
+export function backfillCommunityFeedPublished() {
+  let published = 0;
+  let touched = 0;
+  for (const entry of polls.values()) {
+    if (entry.publishedAt !== undefined) continue;
+    entry.publishedAt = entry.status === 'open' ? (entry.createdAt || null) : null;
+    if (entry.publishedAt) published += 1;
+    touched += 1;
+  }
+  if (touched > 0) markDirty('poll-index');
+  return published;
+}
+
+export function listByCommunity(community, status = 'open', { publishedOnly = false } = {}) {
   const results = [];
   for (const entry of polls.values()) {
     if (entry.community === community && entry.status === status) {
+      if (publishedOnly && !entry.publishedAt) continue;
       results.push(entry);
     }
   }

--- a/server/src/mcp/tools.js
+++ b/server/src/mcp/tools.js
@@ -1,4 +1,4 @@
-import { indexPoll, updatePollStatus, listByCommunity } from '../lib/pollIndex.js';
+import { indexPoll, updatePollStatus, updatePollPublished, listByCommunity } from '../lib/pollIndex.js';
 import { generateIcs } from '../lib/ical.js';
 import { sendEmail } from '../lib/email.js';
 import { getOpenMeetToken } from '../routes/openmeet.js';
@@ -309,6 +309,20 @@ const TOOL_DEFINITIONS = [
           type: 'string',
           description: 'Record key of the poll',
         },
+      },
+      required: ['did', 'rkey'],
+    },
+  },
+  {
+    name: 'publish_to_community_feed',
+    description:
+      "Publish (or unpublish) a poll to its community's dashboard feed in My Community. Creator-only; requires membership of the poll's community. Pass published:false to unpublish.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        did: { type: 'string', description: 'DID of the poll creator' },
+        rkey: { type: 'string', description: 'Record key of the poll' },
+        published: { type: 'boolean', description: 'false to unpublish; defaults to true (publish)' },
       },
       required: ['did', 'rkey'],
     },
@@ -735,9 +749,10 @@ async function sharePoll({ did, rkey, community, topic, message }, authContext) 
 }
 
 async function publishToOpenmeet({ did, rkey }, authContext) {
-  const auth = requireAuth(authContext);
+  if (!authContext) throw new Error('AUTH_REQUIRED');
+  if (!authContext.oauthSession) throw new Error('AUTH_REQUIRED');
+  const auth = authContext;
   if (auth.did !== did) throw new Error('Only the poll creator can publish to OpenMeet');
-  if (!auth.oauthSession) throw new Error('OAuth session not found. Please re-authenticate.');
 
   // Fetch poll from PDS
   const pds = await resolvePds(did);
@@ -840,6 +855,52 @@ async function publishToOpenmeet({ did, rkey }, authContext) {
     startDate: poll.finalTime,
     endDate,
   }, null, 2);
+}
+
+// Publish (published !== false) or unpublish (published === false) a poll to
+// its community's dashboard feed in My Community (#5 sub-project F). Creator-only,
+// gated on the poll's community membership (the same assertMembership gate as
+// share_poll, fails closed). The PDS record's communityFeedPublishedAt is the
+// source of truth (openmeetEventSlug convention: presence = published); the
+// in-memory index mirror is what the public list endpoint filters on, so it is
+// updated only AFTER the authoritative record write succeeds. Shared by the MCP
+// tool and the HTTP route (POST /api/polls/:did/:rkey/publish-community).
+export async function publishToCommunityFeed({ did, rkey, published }, authContext) {
+  if (!authContext) throw new Error('AUTH_REQUIRED');
+  if (!authContext.oauthSession) throw new Error('AUTH_REQUIRED');
+  if (authContext.did !== did) {
+    throw new Error('Only the poll creator can publish it to the community feed');
+  }
+
+  const pds = await resolvePds(did);
+  const getRes = await fetch(
+    `${pds}/xrpc/com.atproto.repo.getRecord?repo=${encodeURIComponent(did)}&collection=${encodeURIComponent(POLL_COLLECTION)}&rkey=${encodeURIComponent(rkey)}`
+  );
+  if (!getRes.ok) throw new Error(`Poll not found: ${getRes.status}`);
+  const existing = await getRes.json();
+  const community = existing.value?.community;
+  if (!community) {
+    throw new Error('This poll has no community set, so it cannot be published to a community feed.');
+  }
+
+  await assertMembership(authContext.did, community);
+
+  const publishedAt = published === false ? null : new Date().toISOString();
+  const updatedRecord = { ...existing.value };
+  if (publishedAt) updatedRecord.communityFeedPublishedAt = publishedAt;
+  else delete updatedRecord.communityFeedPublishedAt;
+
+  await xrpcCall(authContext.oauthSession, 'com.atproto.repo.putRecord', {
+    repo: did,
+    collection: POLL_COLLECTION,
+    rkey,
+    record: updatedRecord,
+    swapRecord: existing.cid,
+  });
+
+  updatePollPublished(did, rkey, publishedAt);
+
+  return JSON.stringify({ ok: true, published: publishedAt !== null, publishedAt, url: pollUrl(did, rkey) });
 }
 
 async function listCommunities() {
@@ -1075,6 +1136,8 @@ export async function callTool(name, args, authContext) {
       return sharePoll(args, authContext);
     case 'publish_to_openmeet':
       return publishToOpenmeet(args, authContext);
+    case 'publish_to_community_feed':
+      return publishToCommunityFeed(args, authContext);
     case 'list_communities':
       return listCommunities();
     case 'schedule_call':

--- a/server/src/routes/polls.js
+++ b/server/src/routes/polls.js
@@ -6,6 +6,7 @@ import { generateIcs } from '../lib/ical.js';
 import { sendEmail } from '../lib/email.js';
 import { deleteOpenMeetEvent } from './openmeet.js';
 import { fetchPollResponses } from '../lib/responseReads.js';
+import { publishToCommunityFeed } from '../mcp/tools.js';
 
 const router = Router();
 
@@ -77,13 +78,15 @@ router.post('/', requireAuth, validatePollCreate, async (req, res, next) => {
   }
 });
 
-// GET / — list polls for a community from the in-memory index
+// GET / — list polls for a community from the in-memory index.
+// published=1 restricts to polls published to the community feed (#5 sub-project F);
+// omitting the param keeps the original behaviour (all matching polls).
 router.get('/', (req, res) => {
-  const { community, status } = req.query;
+  const { community, status, published } = req.query;
   if (!community) {
     return res.status(400).json({ error: 'community query param required' });
   }
-  const polls = listByCommunity(community, status || 'open');
+  const polls = listByCommunity(community, status || 'open', { publishedOnly: published === '1' });
   res.json({ polls });
 });
 
@@ -191,6 +194,28 @@ router.put('/:did/:rkey', requireAuth, validatePollUpdate, async (req, res, next
 
     res.json({ ok: true, poll: updatedRecord });
   } catch (err) {
+    next(err);
+  }
+});
+
+// POST /:did/:rkey/publish-community — publish/unpublish a poll to its
+// community's dashboard feed in My Community (#5 sub-project F). Creator-only,
+// membership-gated. Delegates to the shared publishToCommunityFeed (also the MCP
+// tool) so the web UI and agents run identical logic.
+router.post('/:did/:rkey/publish-community', requireAuth, async (req, res, next) => {
+  try {
+    const { did, rkey } = req.params;
+    const result = await publishToCommunityFeed(
+      { did, rkey, published: req.body?.published !== false },
+      { did: req.userDid, oauthSession: req.oauthSession }
+    );
+    res.json(JSON.parse(result));
+  } catch (err) {
+    const msg = err?.message || '';
+    if (msg === 'AUTH_REQUIRED') return res.status(401).json({ error: 'Authentication required' });
+    if (/Poll not found/i.test(msg)) return res.status(404).json({ error: 'Poll not found' });
+    if (/no community set/i.test(msg)) return res.status(400).json({ error: msg });
+    if (/creator|not a member|verify your membership/i.test(msg)) return res.status(403).json({ error: msg });
     next(err);
   }
 });

--- a/server/test/pollIndex-backfill.test.js
+++ b/server/test/pollIndex-backfill.test.js
@@ -1,0 +1,29 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { indexPoll, updatePollPublished, listByCommunity, backfillCommunityFeedPublished } from '../src/lib/pollIndex.js';
+
+// The backfill grandfathers polls indexed before the community-feed field existed.
+// listByCommunity returns entries by reference, so deleting publishedAt off a
+// returned object simulates a pre-migration entry (field strictly undefined).
+describe('community-feed backfill (grandfather open polls)', () => {
+  it('grandfathers open polls, leaves closed unpublished, and is idempotent', () => {
+    indexPoll('did:plc:a', 'bf-open', { title: 'O', community: 'c-bf', status: 'open', createdAt: '2026-06-01T00:00:00Z' });
+    indexPoll('did:plc:a', 'bf-closed', { title: 'C', community: 'c-bf', status: 'closed', createdAt: '2026-06-02T00:00:00Z' });
+    delete listByCommunity('c-bf', 'open')[0].publishedAt;
+    delete listByCommunity('c-bf', 'closed')[0].publishedAt;
+
+    const published = backfillCommunityFeedPublished();
+    assert.equal(published, 1);
+    assert.equal(listByCommunity('c-bf', 'open')[0].publishedAt, '2026-06-01T00:00:00Z');
+    assert.equal(listByCommunity('c-bf', 'closed')[0].publishedAt, null);
+
+    assert.equal(backfillCommunityFeedPublished(), 0); // second pass: nothing left to migrate
+  });
+
+  it('never re-publishes a poll that was explicitly unpublished (publishedAt = null)', () => {
+    indexPoll('did:plc:a', 'bf-unpub', { title: 'U', community: 'c-bf2', status: 'open', createdAt: '2026-06-01T00:00:00Z' });
+    updatePollPublished('did:plc:a', 'bf-unpub', null);
+    assert.equal(backfillCommunityFeedPublished(), 0);
+    assert.equal(listByCommunity('c-bf2', 'open')[0].publishedAt, null);
+  });
+});

--- a/server/test/pollIndex-published.test.js
+++ b/server/test/pollIndex-published.test.js
@@ -1,0 +1,35 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { indexPoll, updatePollPublished, listByCommunity } from '../src/lib/pollIndex.js';
+
+// Community-feed publish flag (#5 sub-project F): a poll's PDS record carries
+// communityFeedPublishedAt; the index mirrors it as publishedAt so the list
+// endpoint can filter on it. Each test uses a distinct community so the
+// module-level Map (shared across it() blocks in this one process) can't collide.
+describe('poll index community-feed publish flag', () => {
+  it('indexPoll defaults publishedAt to null; updatePollPublished sets and clears it', () => {
+    indexPoll('did:plc:a', 'p1', { title: 'P1', community: 'c-set', status: 'open', createdAt: '2026-07-01T00:00:00Z' });
+    assert.equal(listByCommunity('c-set')[0].publishedAt, null);
+    updatePollPublished('did:plc:a', 'p1', '2026-07-19T12:00:00Z');
+    assert.equal(listByCommunity('c-set')[0].publishedAt, '2026-07-19T12:00:00Z');
+    updatePollPublished('did:plc:a', 'p1', null);
+    assert.equal(listByCommunity('c-set')[0].publishedAt, null);
+  });
+
+  it('re-indexing an existing poll preserves publishedAt', () => {
+    indexPoll('did:plc:a', 'p2', { title: 'P2', community: 'c-preserve', status: 'open', createdAt: '2026-07-01T00:00:00Z' });
+    updatePollPublished('did:plc:a', 'p2', '2026-07-19T12:00:00Z');
+    indexPoll('did:plc:a', 'p2', { title: 'P2 renamed', community: 'c-preserve', status: 'open', createdAt: '2026-07-01T00:00:00Z' });
+    const entry = listByCommunity('c-preserve')[0];
+    assert.equal(entry.publishedAt, '2026-07-19T12:00:00Z');
+    assert.equal(entry.title, 'P2 renamed');
+  });
+
+  it('listByCommunity publishedOnly filters to published polls; no opts stays back-compatible', () => {
+    indexPoll('did:plc:a', 'u1', { title: 'U1', community: 'c-filter', status: 'open', createdAt: '2026-07-01T00:00:00Z' });
+    indexPoll('did:plc:a', 'u2', { title: 'U2', community: 'c-filter', status: 'open', createdAt: '2026-07-02T00:00:00Z' });
+    updatePollPublished('did:plc:a', 'u2', '2026-07-19T12:00:00Z');
+    assert.deepEqual(listByCommunity('c-filter', 'open', { publishedOnly: true }).map((p) => p.rkey), ['u2']);
+    assert.equal(listByCommunity('c-filter', 'open').length, 2);
+  });
+});

--- a/server/test/polls.published.route.test.js
+++ b/server/test/polls.published.route.test.js
@@ -1,0 +1,50 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import { indexPoll, updatePollPublished } from '../src/lib/pollIndex.js';
+
+const originalFetch = globalThis.fetch;
+const { default: pollRoutes } = await import('../src/routes/polls.js');
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/polls', pollRoutes);
+  return app;
+}
+
+async function request(app, path) {
+  const { once } = await import('node:events');
+  const server = app.listen(0);
+  await once(server, 'listening');
+  const port = server.address().port;
+  try {
+    const res = await originalFetch(`http://localhost:${port}${path}`);
+    return { status: res.status, body: await res.json().catch(() => null) };
+  } finally {
+    server.close();
+  }
+}
+
+describe('GET /api/polls published filter', () => {
+  it('returns all open polls without the param, published-only with published=1', async () => {
+    indexPoll('did:plc:a', 'rt1', { title: 'RT1', community: 'c-route', status: 'open', createdAt: '2026-07-01T00:00:00Z' });
+    indexPoll('did:plc:a', 'rt2', { title: 'RT2', community: 'c-route', status: 'open', createdAt: '2026-07-02T00:00:00Z' });
+    updatePollPublished('did:plc:a', 'rt2', '2026-07-19T12:00:00Z');
+    const app = createApp();
+
+    const all = await request(app, '/api/polls?community=c-route');
+    assert.equal(all.status, 200);
+    assert.equal(all.body.polls.length, 2);
+
+    const pub = await request(app, '/api/polls?community=c-route&published=1');
+    assert.equal(pub.status, 200);
+    assert.deepEqual(pub.body.polls.map((p) => p.rkey), ['rt2']);
+  });
+
+  it('still 400s without a community param', async () => {
+    const app = createApp();
+    const res = await request(app, '/api/polls');
+    assert.equal(res.status, 400);
+  });
+});

--- a/server/test/publish-community-feed.test.js
+++ b/server/test/publish-community-feed.test.js
@@ -1,0 +1,112 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.CA_MEMBERSHIP_URL = 'https://ca.test';
+process.env.CA_CONFIG_SECRET = 'svc';
+
+// Control the membership gate per test via mock.module.
+let membershipOk = true;
+import { mock } from 'node:test';
+mock.module('../src/lib/membership.js', {
+  namedExports: {
+    assertMembership: async (_did, community) => {
+      if (!membershipOk) throw new Error(`You're not a member of "${community}".`);
+    },
+  },
+});
+
+// PDS reads go through global fetch (resolvePds + getRecord); the PDS WRITE goes
+// through authContext.oauthSession.fetchHandler, so it never touches global fetch.
+let pollRecord = null;
+globalThis.fetch = async (url) => {
+  const u = String(url);
+  if (u.includes('plc.directory')) {
+    return { ok: true, json: async () => ({ service: [{ id: '#atproto_pds', serviceEndpoint: 'https://pds.test' }] }) };
+  }
+  if (u.includes('getRecord')) {
+    if (!pollRecord) return { ok: false, status: 404 };
+    return { ok: true, json: async () => pollRecord };
+  }
+  return { ok: true, json: async () => ({}) };
+};
+
+const { publishToCommunityFeed } = await import('../src/mcp/tools.js');
+const { indexPoll, listByCommunity } = await import('../src/lib/pollIndex.js');
+
+const CREATOR = 'did:plc:creator';
+
+function makeOauth() {
+  const putCalls = [];
+  return {
+    putCalls,
+    session: {
+      fetchHandler: async (_path, init) => {
+        putCalls.push(JSON.parse(init.body));
+        return { ok: true, json: async () => ({}) };
+      },
+    },
+  };
+}
+
+function seedPoll(rkey, community) {
+  pollRecord = { value: { title: 'P', community, status: 'open', createdAt: '2026-07-01T00:00:00Z' }, cid: 'cid1' };
+  if (community) indexPoll(CREATOR, rkey, { title: 'P', community, status: 'open', createdAt: '2026-07-01T00:00:00Z' });
+}
+
+describe('publishToCommunityFeed', () => {
+  it('rejects without auth or without an oauthSession', async () => {
+    await assert.rejects(() => publishToCommunityFeed({ did: CREATOR, rkey: 'r1' }, null), /AUTH_REQUIRED/);
+    await assert.rejects(() => publishToCommunityFeed({ did: CREATOR, rkey: 'r1' }, { did: CREATOR }), /AUTH_REQUIRED/);
+  });
+
+  it('rejects a non-creator without touching membership or the index', async () => {
+    membershipOk = true;
+    seedPoll('r-nc', 'c-nc');
+    const { session, putCalls } = makeOauth();
+    await assert.rejects(
+      () => publishToCommunityFeed({ did: CREATOR, rkey: 'r-nc' }, { did: 'did:plc:other', oauthSession: session }),
+      /creator/
+    );
+    assert.equal(putCalls.length, 0);
+    assert.equal(listByCommunity('c-nc', 'open', { publishedOnly: true }).length, 0);
+  });
+
+  it('publishes: sets communityFeedPublishedAt on the record and mirrors to the index', async () => {
+    membershipOk = true;
+    seedPoll('r-pub', 'c-pub');
+    const { session, putCalls } = makeOauth();
+    const out = JSON.parse(await publishToCommunityFeed({ did: CREATOR, rkey: 'r-pub' }, { did: CREATOR, oauthSession: session }));
+    assert.equal(out.published, true);
+    assert.equal(putCalls.length, 1);
+    assert.ok(putCalls[0].record.communityFeedPublishedAt);
+    const listed = listByCommunity('c-pub', 'open', { publishedOnly: true });
+    assert.deepEqual(listed.map((p) => p.rkey), ['r-pub']);
+  });
+
+  it('unpublishes: published=false clears the field and the index flag', async () => {
+    membershipOk = true;
+    seedPoll('r-un', 'c-un');
+    const { session, putCalls } = makeOauth();
+    await publishToCommunityFeed({ did: CREATOR, rkey: 'r-un' }, { did: CREATOR, oauthSession: session });
+    const out = JSON.parse(await publishToCommunityFeed({ did: CREATOR, rkey: 'r-un', published: false }, { did: CREATOR, oauthSession: session }));
+    assert.equal(out.published, false);
+    assert.equal('communityFeedPublishedAt' in putCalls[1].record, false);
+    assert.equal(listByCommunity('c-un', 'open', { publishedOnly: true }).length, 0);
+  });
+
+  it('a non-member is rejected before any PDS write', async () => {
+    membershipOk = false;
+    seedPoll('r-nm', 'c-nm');
+    const { session, putCalls } = makeOauth();
+    await assert.rejects(() => publishToCommunityFeed({ did: CREATOR, rkey: 'r-nm' }, { did: CREATOR, oauthSession: session }), /not a member/);
+    assert.equal(putCalls.length, 0);
+    assert.equal(listByCommunity('c-nm', 'open', { publishedOnly: true }).length, 0);
+  });
+
+  it('a poll with no community is rejected', async () => {
+    membershipOk = true;
+    pollRecord = { value: { title: 'P', status: 'open', createdAt: '2026-07-01T00:00:00Z' }, cid: 'cid1' };
+    const { session } = makeOauth();
+    await assert.rejects(() => publishToCommunityFeed({ did: CREATOR, rkey: 'r-noc' }, { did: CREATOR, oauthSession: session }), /no community set/);
+  });
+});

--- a/server/test/publish-openmeet-auth.test.js
+++ b/server/test/publish-openmeet-auth.test.js
@@ -1,0 +1,27 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Regression guard: publish_to_openmeet called an undefined requireAuth(), so it
+// threw ReferenceError before any auth check. It must reject unauthenticated
+// calls with AUTH_REQUIRED instead.
+const { callTool } = await import('../src/mcp/tools.js');
+
+describe('publish_to_openmeet auth', () => {
+  it('throws AUTH_REQUIRED (not ReferenceError) with no auth context', async () => {
+    await assert.rejects(
+      () => callTool('publish_to_openmeet', { did: 'did:plc:x', rkey: 'r1' }, null),
+      (err) => {
+        assert.match(err.message, /AUTH_REQUIRED/);
+        assert.doesNotMatch(err.message, /is not defined/);
+        return true;
+      }
+    );
+  });
+
+  it('throws AUTH_REQUIRED when the auth context has no oauthSession', async () => {
+    await assert.rejects(
+      () => callTool('publish_to_openmeet', { did: 'did:plc:x', rkey: 'r1' }, { did: 'did:plc:x' }),
+      /AUTH_REQUIRED/
+    );
+  });
+});


### PR DESCRIPTION
## What

Backend for sub-project F: publish avails polls to a community's My Community dashboard feed.

- **`communityFeedPublishedAt`** on the poll PDS record marks it published (presence = published, the `openmeetEventSlug` convention). The in-memory poll index mirrors it so the list endpoint can filter; the record is source of truth and the index updates only after the write succeeds.
- **One shared `publishToCommunityFeed`** behind two entry points that run identical logic: the `publish_to_community_feed` MCP tool and `POST /api/polls/:did/:rkey/publish-community` (for the web UI). Creator-only, gated on community membership via the existing `assertMembership` (same gate as `share_poll`, fails closed).
- **`GET /api/polls?published=1`** opt-in filter. Without the param, behaviour is unchanged.
- **One-time startup backfill** grandfathers currently-open polls as published, so existing polls stay visible when the feed goes opt-in. Idempotent across restarts (only pre-migration entries lacking the field are touched); an explicit unpublish sticks. Index-only, since the server cannot write other creators' PDS records.
- **Bug fix:** `publish_to_openmeet` called an undefined `requireAuth(authContext)` and threw `ReferenceError` on every MCP call, so that tool was entirely broken via MCP. Replaced with the standard `AUTH_REQUIRED` + creator-check pattern.

## Tests

152/152 server tests pass (15 new across 5 files). CI syntax check clean.

## Follow-ups (not in this PR)

- PollView web-UI Publish/Unpublish button (needs this deployed to verify; UI work).
- My Community poll cards consuming `?published=1` (blocked on this deploying).
- Two pre-existing bugs found during the code check, to be filed separately: dead `/poll/` URLs in calendar-invite emails; lexicon `status` enum missing `finalized`.

Refs Citizen-Infra/my-community#5 (sub-project F).
