### PR TITLE
Fix poll-creator community dropdown: source from community-admin (#134)

### DIFF
--- a/server/src/lib/communityConfig.js
+++ b/server/src/lib/communityConfig.js
@@ -1,0 +1,21 @@
+// community-admin is the source of truth for community config (IdP S2) — it emits
+// active communities with a Telegram group_id + output_channel + topics + visibility.
+// Read directly from /api/config (Bearer CA_CONFIG_SECRET), reusing the same
+// community-admin base as the S4 membership gate. scenius-digest is no longer in
+// this path (it was a temporary middleman, unrelated to scheduling).
+//
+// Returns the raw communities object keyed by id: { <id>: { name, group_id,
+// output_channel, topics, visibility, ... } }. Callers shape/filter it as needed
+// (the MCP list_communities tool returns all; the unauthenticated web route
+// filters to public — see routes/communities.js).
+export async function fetchCommunityConfig() {
+  const base = process.env.CA_MEMBERSHIP_URL?.replace(/\/$/, '');
+  const secret = process.env.CA_CONFIG_SECRET;
+  if (!base || !secret) {
+    throw new Error('Community config is not configured (CA_MEMBERSHIP_URL / CA_CONFIG_SECRET).');
+  }
+  const res = await fetch(`${base}/api/config`, { headers: { Authorization: `Bearer ${secret}` } });
+  if (!res.ok) throw new Error(`Failed to fetch community config: ${res.status}`);
+  const data = await res.json();
+  return data.communities || {};
+}

--- a/server/src/mcp/tools.js
+++ b/server/src/mcp/tools.js
@@ -7,6 +7,7 @@ import { sendTelegramMessage } from './telegram.js';
 import { assertMembership } from '../lib/membership.js';
 import { resolveListAvailability, resolveAvailabilityForDids } from './listMembers.js';
 import { bestCallSlots } from './availabilityOverlap.js';
+import { fetchCommunityConfig } from '../lib/communityConfig.js';
 
 const POLL_COLLECTION = 'chat.avails.scheduling.poll';
 const RESPONSE_COLLECTION = 'chat.avails.scheduling.response';
@@ -63,22 +64,9 @@ function pollUrl(did, rkey) {
   return `${base}/p/${did}/${rkey}`;
 }
 
-// community-admin is the source of truth for community config (IdP S2) — it
-// emits active communities with a Telegram group_id + output_channel + topics.
-// We read it directly from /api/config (Bearer CA_CONFIG_SECRET), reusing the
-// same community-admin base as the S4 membership gate. scenius-digest is no
-// longer in this path (it was a temporary middleman, unrelated to scheduling).
-async function fetchCommunityGroups() {
-  const base = process.env.CA_MEMBERSHIP_URL?.replace(/\/$/, '');
-  const secret = process.env.CA_CONFIG_SECRET;
-  if (!base || !secret) {
-    throw new Error('Community config is not configured (CA_MEMBERSHIP_URL / CA_CONFIG_SECRET).');
-  }
-  const res = await fetch(`${base}/api/config`, { headers: { Authorization: `Bearer ${secret}` } });
-  if (!res.ok) throw new Error(`Failed to fetch community config: ${res.status}`);
-  const data = await res.json();
-  return data.communities || {};
-}
+// Community config now comes from the shared lib/communityConfig.js helper
+// (fetchCommunityConfig), which both this MCP path and the web /api/communities
+// route use — CA /api/config is the single source of truth (IdP S2).
 
 // ---------------------------------------------------------------------------
 // Tool definitions
@@ -667,7 +655,7 @@ async function sharePoll({ did, rkey, community, topic, message }, authContext) 
   const poll = pollData.value;
 
   // Fetch community config from scenius-digest API (authenticated: includes chat IDs)
-  const groups = await fetchCommunityGroups();
+  const groups = await fetchCommunityConfig();
 
   const communityConfig = groups[community];
   if (!communityConfig) {
@@ -904,7 +892,7 @@ export async function publishToCommunityFeed({ did, rkey, published }, authConte
 }
 
 async function listCommunities() {
-  const groups = await fetchCommunityGroups();
+  const groups = await fetchCommunityConfig();
 
   const communities = Object.entries(groups).map(([key, cfg]) => ({
     key,

--- a/server/src/routes/communities.js
+++ b/server/src/routes/communities.js
@@ -1,12 +1,22 @@
 import { Router } from 'express';
+import { fetchCommunityConfig } from '../lib/communityConfig.js';
 
 const router = Router();
 
+// The poll-creator's community dropdown. Sources from community-admin (the source
+// of truth since IdP S2 — NOT scenius-digest) and returns [{ id, name }] so the
+// client <Select> can render it. This route is unauthenticated, so it exposes
+// PUBLIC communities only — CA /api/config returns private communities too, and
+// leaking their names to anonymous callers would be a privacy regression.
+// (Membership-aware inclusion of a signed-in user's own private communities is a
+// follow-up: authenticate the caller + filter by /api/memberships.)
 router.get('/', async (req, res) => {
   try {
-    const response = await fetch('https://scenius-digest.vercel.app/api/groups');
-    const data = await response.json();
-    res.json(data);
+    const communities = await fetchCommunityConfig();
+    const list = Object.entries(communities)
+      .filter(([, c]) => c.visibility !== 'private')
+      .map(([id, c]) => ({ id, name: c.name }));
+    res.json(list);
   } catch (err) {
     console.error('Communities fetch error:', err);
     res.status(502).json({ error: 'Failed to fetch communities' });

--- a/server/test/communities.route.test.js
+++ b/server/test/communities.route.test.js
@@ -1,0 +1,70 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+
+process.env.CA_MEMBERSHIP_URL = 'https://ca.test';
+process.env.CA_CONFIG_SECRET = 'svc-secret';
+
+let fetchImpl;
+const originalFetch = globalThis.fetch;
+globalThis.fetch = (...a) => fetchImpl(...a);
+
+const { default: communitiesRoutes } = await import('../src/routes/communities.js');
+
+function createApp() {
+  const app = express();
+  app.use('/api/communities', communitiesRoutes);
+  return app;
+}
+
+async function request(app, path) {
+  const { once } = await import('node:events');
+  const server = app.listen(0);
+  await once(server, 'listening');
+  const port = server.address().port;
+  try {
+    const res = await originalFetch(`http://localhost:${port}${path}`);
+    return { status: res.status, body: await res.json().catch(() => null) };
+  } finally {
+    server.close();
+  }
+}
+
+describe('GET /api/communities', () => {
+  it('reads community-admin /api/config with the service bearer and returns [{id,name}] (public only)', async () => {
+    let captured;
+    fetchImpl = async (url, opts) => {
+      captured = { url: String(url), auth: opts?.headers?.Authorization };
+      return { ok: true, json: async () => ({ communities: {
+        cibc: { name: 'Citizen Infra Builders', visibility: 'public' },
+        priv: { name: 'Secret Room', visibility: 'private' },
+      } }) };
+    };
+    const app = createApp();
+    const res = await request(app, '/api/communities');
+    assert.equal(res.status, 200);
+    assert.match(captured.url, /^https:\/\/ca\.test\/api\/config$/);
+    assert.equal(captured.auth, 'Bearer svc-secret');
+    assert.ok(Array.isArray(res.body), 'body must be an array the client Select can map');
+    // Private community must NOT leak to the unauthenticated web route.
+    assert.deepEqual(res.body, [{ id: 'cibc', name: 'Citizen Infra Builders' }]);
+  });
+
+  it('does not call scenius-digest', async () => {
+    let calledScenius = false;
+    fetchImpl = async (url) => {
+      if (String(url).includes('scenius-digest')) calledScenius = true;
+      return { ok: true, json: async () => ({ communities: {} }) };
+    };
+    const app = createApp();
+    await request(app, '/api/communities');
+    assert.equal(calledScenius, false, 'the deprecated scenius-digest path must be gone');
+  });
+
+  it('502s when community-admin is unreachable', async () => {
+    fetchImpl = async () => { throw new Error('network down'); };
+    const app = createApp();
+    const res = await request(app, '/api/communities');
+    assert.equal(res.status, 502);
+  });
+});


### PR DESCRIPTION
Fixes #134 — the poll-creator's **Community** dropdown never rendered.

## Two root causes

1. **Migration gap.** community-admin became the source of truth for community config in IdP S2. The MCP path (`mcp/tools.js` → CA `/api/config`) and membership gating (`lib/membership.js` → CA `/api/memberships`) moved over, but **`routes/communities.js` — the web poll-creator dropdown — was left calling the deprecated `scenius-digest.vercel.app/api/groups`.**
2. **Shape mismatch.** `/api/communities` returned an object (`{groups:{id:{name}}}`); the client expects an array `[{id,name}]` and gates the field on `communities.length > 0`. An object has no `.length`, so the field silently never rendered — since the feature shipped, independent of the migration.

Not caused by the 2026-07-18 service-repo change (#128) — that touched response storage, never this route or the form.

## Change

- **New `lib/communityConfig.js`** (`fetchCommunityConfig`) — extracted verbatim from `mcp/tools.js`'s `fetchCommunityGroups`. Single source of truth for reading CA `/api/config`. Behavior-preserving for the MCP path (`mcp-list-communities.test.js` stays green).
- **`routes/communities.js`** now reads CA via that helper and returns `[{id, name}]` so the client `<Select>` renders. Filters to **public** communities: this route is unauthenticated, and CA `/api/config` (service secret) also returns private communities — returning them would leak private names to anonymous callers.
- **`mcp/tools.js`** imports the shared helper; the two call sites are unchanged in behavior.

## Tests

155/155 green. New `communities.route.test.js`: asserts the route hits CA `/api/config` with the service Bearer, returns the array shape, excludes private communities, and no longer touches scenius-digest.

## Follow-up (tracked, not here)

Showing a signed-in user *their own* private communities needs the route authenticated + filtered by the caller's `/api/memberships`. Noted in #134.

## Deploy note

Behavior depends on `CA_MEMBERSHIP_URL` + `CA_CONFIG_SECRET` (already set in prod for the S4 membership gate and the MCP config path) — no new env vars.
