### PR TITLE
Fix advanced-panel crash: community Select had an empty-string SelectItem value

### DIFF
--- a/client/src/components/PollCreator.jsx
+++ b/client/src/components/PollCreator.jsx
@@ -206,12 +206,14 @@ export default function PollCreator() {
               {communities.length > 0 && (
                 <div className="space-y-2">
                   <Label htmlFor="community" className="text-base font-medium text-[#1a1a1a]">Community <span className="text-[#a09a94] text-xs font-normal">(optional)</span></Label>
-                  <Select value={communityId} onValueChange={setCommunityId}>
+                  {/* Radix forbids a SelectItem value="" — use a sentinel for "None"
+                      and map it back to the empty communityId the submit path expects. */}
+                  <Select value={communityId || '__none__'} onValueChange={v => setCommunityId(v === '__none__' ? '' : v)}>
                     <SelectTrigger id="community" className="border-[#e8e5df] bg-white text-[#1a1a1a]">
                       <SelectValue placeholder="None" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="">None</SelectItem>
+                      <SelectItem value="__none__">None</SelectItem>
                       {communities.map(c => (
                         <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>
                       ))}


### PR DESCRIPTION
## Bug

Opening "More options" in the poll creator crashes with:

> A `<Select.Item />` must have a value prop that is not an empty string.

## Cause

`PollCreator.jsx` had `<SelectItem value="">None</SelectItem>` for the Community picker's "None" option — Radix forbids an empty-string item value. It was **dead code** until now: the community block only renders when `communities.length > 0`, and `/api/communities` used to return an object (no `.length`), so the block never rendered. #135 fixed that route to return an array, which populated the list, rendered the block, and surfaced this latent crash.

So this is a bug **exposed by #135**, not introduced by it — the invalid `value=""` predates it.

## Fix

Use a `'__none__'` sentinel for the None item and map it back to the empty `communityId` the submit path already expects:

```jsx
<Select value={communityId || '__none__'} onValueChange={v => setCommunityId(v === '__none__' ? '' : v)}>
  ...
  <SelectItem value="__none__">None</SelectItem>
```

`communityId` state semantics are unchanged (`''` = no community → `communityId || undefined` on submit), so no server-side or payload change. Grep confirms this was the only empty-value `SelectItem` in the client.

## Verification

- `cd client && npm run build` passes.
- By construction, no `<SelectItem>` has an empty value anymore, so the specific Radix error cannot fire.
- Runtime click-through (open "More options" → no crash, None + CIBC selectable) to confirm live post-deploy.
