### PR TITLE
Fix poll-create community selection being silently dropped (#138)

### DIFF
--- a/client/src/components/PollCreator.jsx
+++ b/client/src/components/PollCreator.jsx
@@ -63,7 +63,7 @@ export default function PollCreator() {
         timeRange: { start: earliestTime, end: latestTime },
         slotMinutes: parseInt(slotDuration, 10),
         timezone: TIMEZONE,
-        communityId: communityId || undefined,
+        community: communityId || undefined,
         notifyAfter: notifyAfter ? parseInt(notifyAfter, 10) : undefined,
         notifyEmail: notifyEmail.trim() || undefined,
         hideResponsesUntilSubmit: hideResponsesUntilSubmit || undefined,


### PR DESCRIPTION
Part 1 of #138 — the create-time bug.

## Bug

Picking a community in the poll-create form never persisted. `PollCreator` sent the field as **`communityId`**; the server create validator reads **`community`** (as do the stored record, the poll index, and the MCP `create_poll` tool). No mapping bridged the two, so the selection was silently dropped on every web-created poll.

`grep communityId server/src` → nothing; PollCreator has sent `communityId` since its first commit. Latent the whole time — invisible until #135 (dropdown renders) + #137 (no crash) made the picker actually usable.

## Fix

One line: the client now sends `community` instead of `communityId`, matching the server contract. State/UX unchanged; `communityId || undefined` still means "no community."

## Verification

- `cd client && npm run build` passes.
- Field names now match the server (`community` read by `validatePollCreate`, stored on the record, indexed by `indexPoll`), so the selection flows through.
- Live check post-deploy: create a poll with a community selected → it carries the community (badge shows, community-feed publish button appears).

Part 2 (#138) — linking an *existing* poll — is a separate PR (adds `community` to the update validator + a poll-view control).
