### PR TITLE
Link an existing poll to a community (#138, part 2)

### DIFF
--- a/client/src/pages/PollView.jsx
+++ b/client/src/pages/PollView.jsx
@@ -1,7 +1,7 @@
 import Logo from '@/components/Logo'
 import { useEffect, useState, useCallback, useMemo } from 'react'
 import { useParams } from 'react-router'
-import { getPoll, getSession, submitResponse, updateResponse, finalizePoll, unfinalizePoll, deleteResponse, publishToOpenMeet, publishToCommunityFeed, getOpenMeetAvailability, setGoogleCalendarEvent } from '@/lib/api'
+import { getPoll, getSession, submitResponse, updateResponse, finalizePoll, unfinalizePoll, deleteResponse, publishToOpenMeet, publishToCommunityFeed, getOpenMeetAvailability, setGoogleCalendarEvent, getCommunities, updatePoll } from '@/lib/api'
 import {
   isGoogleConfigured,
   requestGoogleAccess,
@@ -13,6 +13,7 @@ import {
 } from '@/lib/googleCalendar'
 import { convertPollTimesToViewer, convertSlotsToViewer, convertSlotsToCreator, getViewerTimezone, needsConversion } from '@/lib/timezone'
 import { Button } from '@/components/ui/button'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import AvailGrid from '@/components/AvailGrid'
 import SchedulingGrid from '@/components/SchedulingGrid'
 import NameEntry from '@/components/NameEntry'
@@ -80,7 +81,15 @@ export default function PollView() {
   const [publishingToFeed, setPublishingToFeed] = useState(false)
   const [feedError, setFeedError] = useState(null)
   const [feedPublished, setFeedPublished] = useState(null)
+  // Community linking (#138): the creator can set/change/clear the poll's community.
+  const [communities, setCommunities] = useState([])
+  const [savingCommunity, setSavingCommunity] = useState(false)
+  const [communityError, setCommunityError] = useState(null)
   const [showBreakdown, setShowBreakdown] = useState(false)
+
+  useEffect(() => {
+    getCommunities().then(setCommunities).catch(() => setCommunities([]))
+  }, [])
 
   const [busySlots, setBusySlots] = useState(new Set())
   const [slotEvents, setSlotEvents] = useState({})
@@ -580,6 +589,22 @@ export default function PollView() {
     }
   }
 
+  // Link / relink / unlink the poll's community. `next` is a community id, or ''
+  // to unlink. Optimistically reflects the change so the feed control appears.
+  async function handleSetCommunity(next) {
+    setSavingCommunity(true)
+    setCommunityError(null)
+    try {
+      await updatePoll(did, rkey, { community: next })
+      setPoll(prev => ({ ...prev, community: next }))
+    } catch (err) {
+      console.error('Set community error:', err)
+      setCommunityError(err.message || 'Failed to update the community')
+    } finally {
+      setSavingCommunity(false)
+    }
+  }
+
   if (loading) {
     return (
       <div className="min-h-screen bg-[#faf9f6] flex items-center justify-center">
@@ -615,6 +640,7 @@ export default function PollView() {
   const isOpen = !poll.finalTime
   const isCreator = session?.did === did
   const feedIsPublished = feedPublished === null ? !!poll.communityFeedPublishedAt : feedPublished
+  const communityName = communities.find(c => c.id === poll.community)?.name || poll.community
   const creatorTz = poll.timezone
   const showTzNotice = needsConversion(creatorTz)
 
@@ -771,29 +797,56 @@ export default function PollView() {
           </div>
         )}
 
-        {/* Creator: publish an open poll to its community's dashboard feed (#5 sub-project F) */}
-        {isOpen && isCreator && poll.community && (
-          <div className="rounded-xl border border-[#e8e5df] bg-[#faf9f6] p-5 sm:p-6">
+        {/* Creator: link the poll to a community, then publish it to that
+            community's dashboard feed. The feed row appears once a community is
+            set (#138 selector merged with the #5 sub-project F publish control). */}
+        {isOpen && isCreator && (communities.length > 0 || poll.community) && (
+          <div className="rounded-xl border border-[#e8e5df] bg-[#faf9f6] p-5 sm:p-6 space-y-4">
             <div className="flex items-center justify-between gap-4 flex-wrap">
               <div className="space-y-0.5">
-                <p className="text-sm font-medium text-[#1a1a1a]">Community feed</p>
-                <p className="text-sm text-[#8a8580]">
-                  {feedIsPublished
-                    ? `Showing on the ${poll.community} dashboard so members find it without opening chat.`
-                    : `Publish to the ${poll.community} dashboard so members find it without opening chat.`}
-                </p>
+                <p className="text-sm font-medium text-[#1a1a1a]">Community</p>
+                <p className="text-sm text-[#8a8580]">Choose the community this poll belongs to.</p>
               </div>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => handlePublishToCommunityFeed(!feedIsPublished)}
-                disabled={publishingToFeed}
-                className="border-[#0d9488] text-[#0d9488] hover:bg-[#ccfbf1] shrink-0"
+              <Select
+                value={poll.community || '__none__'}
+                onValueChange={v => handleSetCommunity(v === '__none__' ? '' : v)}
+                disabled={savingCommunity}
               >
-                {publishingToFeed ? 'Saving…' : feedIsPublished ? 'Unpublish' : 'Publish to community feed'}
-              </Button>
+                <SelectTrigger aria-label="Community" className="w-full sm:w-[220px] border-[#e8e5df] bg-white text-[#1a1a1a]">
+                  <SelectValue placeholder="None" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__none__">None</SelectItem>
+                  {communities.map(c => (
+                    <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
-            {feedError && <p className="text-sm text-red-600 mt-2">{feedError}</p>}
+            {communityError && <p className="text-sm text-red-600">{communityError}</p>}
+
+            {poll.community && (
+              <div className="flex items-center justify-between gap-4 flex-wrap border-t border-[#e8e5df] pt-4">
+                <div className="space-y-0.5">
+                  <p className="text-sm font-medium text-[#1a1a1a]">Community feed</p>
+                  <p className="text-sm text-[#8a8580]">
+                    {feedIsPublished
+                      ? `Showing on the ${communityName} dashboard so members find it without opening chat.`
+                      : `Publish to the ${communityName} dashboard so members find it without opening chat.`}
+                  </p>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handlePublishToCommunityFeed(!feedIsPublished)}
+                  disabled={publishingToFeed}
+                  className="border-[#0d9488] text-[#0d9488] hover:bg-[#ccfbf1] shrink-0"
+                >
+                  {publishingToFeed ? 'Saving…' : feedIsPublished ? 'Unpublish' : 'Publish to community feed'}
+                </Button>
+              </div>
+            )}
+            {feedError && <p className="text-sm text-red-600">{feedError}</p>}
           </div>
         )}
 

--- a/server/src/lib/pollIndex.js
+++ b/server/src/lib/pollIndex.js
@@ -34,6 +34,18 @@ export function updatePollStatus(did, rkey, status) {
   }
 }
 
+// Re-point a poll's community without disturbing its responseCount/status.
+// Called when an existing poll is linked/relinked so listByCommunity (discovery
+// + community feed) reflects the change.
+export function updatePollCommunity(did, rkey, community) {
+  const key = `${did}/${rkey}`;
+  const entry = polls.get(key);
+  if (entry) {
+    polls.set(key, { ...entry, community });
+    markDirty('poll-index');
+  }
+}
+
 // Set (ISO string) or clear (null) a poll's community-feed publish marker.
 export function updatePollPublished(did, rkey, publishedAt) {
   const key = `${did}/${rkey}`;

--- a/server/src/middleware/validate.js
+++ b/server/src/middleware/validate.js
@@ -135,7 +135,7 @@ export function validateResponseCreate(req, res, next) {
 }
 
 export function validatePollUpdate(req, res, next) {
-  const { title, description, dates, timeRange, slotMinutes, hideResponsesUntilSubmit } = req.body;
+  const { title, description, dates, timeRange, slotMinutes, hideResponsesUntilSubmit, community } = req.body;
 
   const errors = [];
 
@@ -176,6 +176,12 @@ export function validatePollUpdate(req, res, next) {
     errors.push('hideResponsesUntilSubmit must be a boolean');
   }
 
+  // community is the group a poll belongs to. Allowed on update so an existing
+  // poll can be linked/relinked (empty string unlinks). String type, same as create.
+  if (community !== undefined && typeof community !== 'string') {
+    errors.push('community must be a string');
+  }
+
   if (errors.length > 0) {
     return res.status(400).json({ error: errors.join('; ') });
   }
@@ -188,6 +194,7 @@ export function validatePollUpdate(req, res, next) {
   if (timeRange !== undefined) req.validatedBody.timeRange = timeRange;
   if (slotMinutes !== undefined) req.validatedBody.slotMinutes = slotMinutes;
   if (hideResponsesUntilSubmit !== undefined) req.validatedBody.hideResponsesUntilSubmit = hideResponsesUntilSubmit;
+  if (community !== undefined) req.validatedBody.community = community;
 
   next();
 }

--- a/server/src/routes/polls.js
+++ b/server/src/routes/polls.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { requireAuth } from '../middleware/auth.js';
 import { validatePollCreate, validatePollUpdate, validateGoogleEvent } from '../middleware/validate.js';
-import { indexPoll, updatePollStatus, removePoll, listByCommunity } from '../lib/pollIndex.js';
+import { indexPoll, updatePollStatus, updatePollCommunity, removePoll, listByCommunity } from '../lib/pollIndex.js';
 import { generateIcs } from '../lib/ical.js';
 import { sendEmail } from '../lib/email.js';
 import { deleteOpenMeetEvent } from './openmeet.js';
@@ -190,6 +190,10 @@ router.put('/:did/:rkey', requireAuth, validatePollUpdate, async (req, res, next
         responseCount: 0,
         createdAt: updatedRecord.createdAt,
       });
+    } else if (req.validatedBody.community !== undefined) {
+      // Community linked/relinked without a title change — re-point the index
+      // (preserving responseCount) so the poll surfaces under the right community.
+      updatePollCommunity(did, rkey, updatedRecord.community);
     }
 
     res.json({ ok: true, poll: updatedRecord });

--- a/server/test/validate.test.js
+++ b/server/test/validate.test.js
@@ -263,6 +263,27 @@ describe('validatePollUpdate', () => {
     assert.ok(!nextCalled());
     assert.equal(res._status, 400);
   });
+
+  it('accepts community to link an existing poll', () => {
+    const { req, res, next, nextCalled } = createMocks({ community: 'cibc' });
+    validatePollUpdate(req, res, next);
+    assert.ok(nextCalled());
+    assert.equal(req.validatedBody.community, 'cibc');
+  });
+
+  it('accepts empty community to unlink', () => {
+    const { req, res, next, nextCalled } = createMocks({ community: '' });
+    validatePollUpdate(req, res, next);
+    assert.ok(nextCalled());
+    assert.equal(req.validatedBody.community, '');
+  });
+
+  it('rejects a non-string community', () => {
+    const { req, res, next, nextCalled } = createMocks({ community: 123 });
+    validatePollUpdate(req, res, next);
+    assert.ok(!nextCalled());
+    assert.equal(res._status, 400);
+  });
 });
 
 // ── validateGoogleEvent ─────────────────────────────────────────────────


### PR DESCRIPTION
Part 2 of #138 — linking an **existing** poll to a community (Part 1, the create-time field fix, is #139).

## What this adds

Previously a poll's community was create-time only (and even that was dropped, see #139). The poll-update validator whitelisted a fixed set of fields that excluded `community`, and no UI existed to set it. This adds both halves.

### Server
- `validatePollUpdate` accepts `community` (string; empty unlinks), so `PUT /:did/:rkey` can set/change it.
- `updatePollCommunity` on the poll index, called on a community-only update (preserving responseCount/status), so a linked poll surfaces under the right community in `listByCommunity` / the community feed.

### Client (shaped via the impeccable design skill against avails' DESIGN.md)
- The standalone "Community feed" card (#132) becomes a single **Community** card in the poll view, for the creator of an open poll:
  - A dropdown (sentinel-value, per the #137 fix) to link / relink / unlink.
  - On change, `updatePoll(did, rkey, { community })` + optimistic local update.
  - Once a community is set, the existing publish-to-feed control appears below a hairline divider.
- On-brand: Paper Cream card, single Gather Teal accent, flat, warm-overridden Select (no cold shadcn neutrals), mobile-first (`flex-wrap`, `w-full sm:w-[220px]`), `aria-label` on the trigger. Feed copy resolves the community name rather than the raw id.

## Tests / verification

- Server: `validatePollUpdate` community cases added; full suite 158/158.
- Client: `npm run build` passes. The interactive click-through (open a poll as creator, pick a community, see the feed control appear) isn't headless-driveable here, so per avails' craft browser-pass fallback it's code-verified + folded into the post-deploy check.

## Note

Community is stored as the community **id** (consistent with create/#139, `listByCommunity`, and MCP `create_poll`). Together with #139, this closes #138.
