### PR TITLE
fix(email): default From pointed at a deleted domain

### DIFF
--- a/server/src/lib/email.js
+++ b/server/src/lib/email.js
@@ -8,7 +8,7 @@ export async function sendEmail({ to, subject, html, attachments }) {
     return;
   }
   return resend.emails.send({
-    from: process.env.RESEND_FROM_EMAIL || 'Avails <noreply@cibc.zhgnv.com>',
+    from: process.env.RESEND_FROM_EMAIL || 'Avails <noreply@citizeninfra.org>',
     to,
     subject,
     html,


### PR DESCRIPTION
One line in `server/src/lib/email.js`. The hardcoded fallback still named `cibc.zhgnv.com`, which was **deleted from Resend** on 2026-08-02 when CIBC's transactional email moved to `citizeninfra.org` (Citizen-Infra/community-admin#98).

The Railway override `RESEND_FROM_EMAIL` is set to `Avails <noreply@citizeninfra.org>`, so this is latent rather than live. But a fallback whose entire purpose is to work when the env var is missing should not name a domain that no longer exists — if the var were ever cleared, every Avails send would fail, and `resend.emails.send()` returns `{ data, error }` rather than throwing, so the failure would be quiet at the call sites that don't inspect it.

Verified with `node --check`. No behaviour change while the env var is set.
