### PR TITLE
fix(email): add a text part, real prose, and escaping by construction

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -108,6 +108,8 @@ A warm, paper-based neutral field with one teal accent and a two-color data sema
 ### Named Rules
 **The Single Voice Rule.** Gather Teal is the only brand hue. If a second accent color is entering a screen, it is a mistake; reach for weight, size, or a neutral instead.
 
+**The Email Link Exception (2026-08-02).** Deep Teal (`#0f766e`) is permitted **alone**, for body-size link text in transactional email only. Gather Teal on Paper Cream measures **3.56:1**, which clears AA for large text and UI but falls under the 4.5:1 required for normal text, and an email body link is normal text. Deep Teal measures **5.28:1**. This is the single carve-out from the companion-only rule above; it does not extend to the app, where teal appears at larger sizes or as a UI surface rather than as body-size text. See `server/src/lib/email-template.js`.
+
 **The No Cold Grey Rule.** Every neutral is warmed toward paper. Pure greys are forbidden on brand surfaces. (Note: the shadcn base layer in `globals.css` ships cold `oklch(... 0 0)` neutrals with chroma 0; those leak coldness into any unstyled shadcn component and must be overridden, not inherited.)
 
 ## 3. Typography

--- a/server/src/lib/email-template.js
+++ b/server/src/lib/email-template.js
@@ -1,0 +1,100 @@
+// One composer for every Avails email, producing the HTML and plain-text parts
+// together from the same input.
+//
+// Why it takes plain text and never HTML: callers used to hand-write HTML
+// fragments, and two of five interpolated user-supplied poll titles straight
+// into markup without escaping. Escaping here rather than at the call sites
+// removes the whole bug class instead of the two instances that happened to
+// exist. It also makes a message with no text part impossible to write, which
+// is the other half of avails#146.
+//
+// Shape follows DESIGN.md's "light brand" register for email: Paper Cream
+// ground, hairline border, flat, text wordmark, one link, no images and no
+// filled button. A heavier promotional layout is measurably worse for inbox
+// placement, and avails sends from a domain with no reputation to spend.
+
+const ESCAPES = { '&': '&amp;', '"': '&quot;', "'": '&#39;', '<': '&lt;', '>': '&gt;' };
+const esc = (s) => String(s).replace(/[&"'<>]/g, (c) => ESCAPES[c]);
+
+const CREAM = '#faf9f6';      // Paper Cream — the ground
+const INK = '#1a1a1a';        // Warm Ink — primary text
+const STONE = '#6b6560';      // Stone — secondary text
+const HAIRLINE = '#e8e5df';   // Hairline — the one rule
+
+// Deep Teal, not Gather Teal, and this is deliberate. Gather Teal (#0d9488) on
+// Paper Cream is 3.56:1 — fine for large text and UI, below WCAG AA's 4.5:1 for
+// body-size text, which is exactly what a link in an email body is. Deep Teal is
+// 5.28:1. DESIGN.md §2 scopes Deep Teal to the scheduled-card gradient and says
+// it never appears alone; this is a documented exception for email body links,
+// recorded in DESIGN.md under Named Rules.
+const LINK = '#0f766e';
+
+// Geist first for the rare client that has it, then the system stack. Webfonts
+// are not loadable in most mail clients, so this honours the One Typeface Rule
+// as far as email allows rather than pretending otherwise.
+const FONT = "'Geist Variable', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif";
+
+/**
+ * Compose an email's HTML and plain-text parts from plain-text input.
+ *
+ * @param {object} opts
+ * @param {string} opts.heading      The answer, stated plainly. Title weight.
+ * @param {string[]} opts.paragraphs Body prose. Plain text; escaped here.
+ * @param {{label: string, url: string}|null} [opts.action] Single optional link.
+ * @param {string} opts.footer       Why this arrived. Plain text.
+ * @returns {{html: string, text: string}}
+ */
+export function composeEmail({ heading, paragraphs = [], action = null, footer }) {
+  const body = paragraphs.filter(Boolean);
+
+  const htmlParagraphs = body
+    .map(
+      (p) =>
+        `<p style="margin:0 0 14px 0;font-size:15px;line-height:1.55;color:${INK};">${esc(p)}</p>`
+    )
+    .join('');
+
+  const htmlAction = action
+    ? `<p style="margin:0 0 4px 0;font-size:15px;line-height:1.55;">` +
+      `<a href="${esc(action.url)}" style="color:${LINK};text-decoration:underline;">${esc(action.label)}</a>` +
+      `</p>`
+    : '';
+
+  const html =
+    `<!doctype html><html lang="en"><head><meta charset="utf-8">` +
+    // Tells supporting clients not to auto-invert. A cream ground forced into
+    // dark mode goes muddy, and the recipient's client is not ours to choose.
+    `<meta name="color-scheme" content="light"><meta name="supported-color-schemes" content="light">` +
+    `<title>${esc(heading)}</title></head>` +
+    `<body style="margin:0;padding:0;background:${CREAM};color-scheme:light;">` +
+    // width must be in CSS as well as the attribute. With the attribute alone
+    // the percentage resolves against a box that ignores the outer padding, so
+    // max-width never clamps and the body clips off the right edge on a phone.
+    // Padding lives on the td, not the table: several clients drop CSS padding
+    // on a table element outright.
+    `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%;table-layout:fixed;background:${CREAM};">` +
+    `<tr><td align="center" style="padding:32px 16px;">` +
+    // table-layout:fixed with word-wrap:break-word guards against a long
+    // unbreakable token (a raw URL used as link text, a long title with no
+    // spaces) forcing the table past its declared width under auto layout.
+    // Precautionary rather than fixing an observed break.
+    `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%;max-width:480px;table-layout:fixed;text-align:left;word-wrap:break-word;">` +
+    `<tr><td style="font-family:${FONT};padding:0 0 22px 0;font-size:13px;font-weight:500;letter-spacing:0.02em;color:${STONE};">avails</td></tr>` +
+    `<tr><td style="font-family:${FONT};">` +
+    `<h1 style="margin:0 0 16px 0;font-size:20px;font-weight:600;line-height:1.3;color:${INK};">${esc(heading)}</h1>` +
+    htmlParagraphs +
+    htmlAction +
+    `<p style="margin:24px 0 0 0;padding-top:16px;border-top:1px solid ${HAIRLINE};font-size:13px;line-height:1.5;color:${STONE};">${esc(footer)}</p>` +
+    `</td></tr></table></td></tr></table></body></html>`;
+
+  const text = [
+    heading,
+    '',
+    ...body.flatMap((p) => [p, '']),
+    ...(action ? [`${action.label}: ${action.url}`, ''] : []),
+    '--',
+    footer,
+  ].join('\n');
+
+  return { html, text };
+}

--- a/server/src/lib/email.js
+++ b/server/src/lib/email.js
@@ -2,7 +2,15 @@ import { Resend } from 'resend';
 
 const resend = process.env.RESEND_API_KEY ? new Resend(process.env.RESEND_API_KEY) : null;
 
-export async function sendEmail({ to, subject, html, attachments }) {
+// `text` is required alongside `html`. An HTML-only message is a spam signal on
+// its own, and avails sends from a domain with no sending reputation to absorb
+// one. Build both parts with composeEmail() in ./email-template.js rather than
+// hand-writing either.
+export async function sendEmail({ to, subject, html, text, attachments }) {
+  // Validate before the configuration check, not after: without a key the
+  // function returns early, so a guard placed below it would never fire in
+  // development or tests and would only surface in production.
+  if (!text) throw new Error(`sendEmail: text part is required (to: ${to})`);
   if (!resend) {
     console.warn('RESEND_API_KEY not set, skipping email to:', to);
     return;
@@ -12,6 +20,7 @@ export async function sendEmail({ to, subject, html, attachments }) {
     to,
     subject,
     html,
+    text,
     attachments,
   });
 }

--- a/server/src/mcp/tools.js
+++ b/server/src/mcp/tools.js
@@ -1,6 +1,7 @@
 import { indexPoll, updatePollStatus, updatePollPublished, listByCommunity } from '../lib/pollIndex.js';
 import { generateIcs } from '../lib/ical.js';
 import { sendEmail } from '../lib/email.js';
+import { composeEmail } from '../lib/email-template.js';
 import { getOpenMeetToken } from '../routes/openmeet.js';
 import { computeBestSlots } from './overlap.js';
 import { sendTelegramMessage } from './telegram.js';
@@ -22,18 +23,10 @@ const MIN_CALL_COVERAGE = 2;
 // Helpers (mirrors patterns from routes/polls.js)
 // ---------------------------------------------------------------------------
 
-// Minimal HTML-escape for caller-controlled strings (e.g. poll/call titles)
-// interpolated into email HTML bodies. Mirrors the escapeHtml in lib/og.js
-// (not exported from there, so duplicated locally rather than reaching into
-// an unrelated module for a 6-line helper).
-function escapeHtml(s) {
-  return String(s)
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-}
+// The local escapeHtml that used to live here is gone: composeEmail() in
+// lib/email-template.js takes plain text and escapes it itself, so no caller
+// hand-writes email HTML any more. lib/og.js keeps its own copy for OG meta
+// tags, which is a different concern.
 
 async function resolvePds(did) {
   const res = await fetch(`https://plc.directory/${encodeURIComponent(did)}`);
@@ -608,12 +601,31 @@ async function schedule({ did, rkey, finalTime, finalDuration }, authContext) {
     const uniqueEmails = [...new Set(emailAddresses)];
 
     if (uniqueEmails.length > 0) {
+      const whenStr = new Date(updatedRecord.finalTime).toLocaleString('en-US', {
+        dateStyle: 'full',
+        timeStyle: 'short',
+        timeZone: updatedRecord.timezone || 'UTC',
+      });
+      // Same message as the REST finalize path in routes/polls.js. If one
+      // changes, change both.
+      const composed = composeEmail({
+        heading: `${updatedRecord.title} is scheduled`,
+        paragraphs: [
+          `${whenStr}, for ${updatedRecord.finalDuration} minutes.`,
+          updatedRecord.description,
+          participants.length > 0 ? `Who answered the poll: ${participants.join(', ')}.` : null,
+          'A calendar invite is attached, so this should appear in your calendar automatically.',
+        ],
+        action: { label: 'View the poll', url },
+        footer:
+          'You are receiving this because you answered this poll or were added to its notification list. No action is needed.',
+      });
       const results = await Promise.allSettled(
         uniqueEmails.map((email) =>
           sendEmail({
             to: email,
             subject: `${updatedRecord.title} — time confirmed`,
-            html: `<p><strong>${updatedRecord.title}</strong> has been scheduled.</p>${updatedRecord.description ? `<p>${updatedRecord.description}</p>` : ''}<p><strong>When:</strong> ${new Date(updatedRecord.finalTime).toLocaleString('en-US', { dateStyle: 'full', timeStyle: 'short', timeZone: updatedRecord.timezone || 'UTC' })} (${updatedRecord.finalDuration} min)</p>${participants.length > 0 ? `<p><strong>Participants:</strong> ${participants.join(', ')}</p>` : ''}<p><a href="${url}">View poll</a></p><p>A calendar invite is attached.</p>`,
+            ...composed,
             attachments: [
               {
                 filename: 'invite.ics',
@@ -1066,13 +1078,25 @@ async function scheduleCall({ scope, durationMinutes, window, title, voterDids }
     .filter((m) => m?.record?.value?.email);
 
   if (emailTargets.length > 0) {
-    const safeTitle = escapeHtml(title);
+    // No poll link here: schedule_call books from standing availability, so
+    // there is no poll page to send anyone to.
+    const composed = composeEmail({
+      heading: `${title} is scheduled`,
+      paragraphs: [
+        `${new Date(finalTime).toUTCString()}, for ${durationMinutes} minutes.`,
+        'This was booked against the availability you already shared, so there was no poll to answer.',
+        'A calendar invite is attached, so this should appear in your calendar automatically.',
+      ],
+      action: null,
+      footer:
+        'You are receiving this because your standing availability covered this time. No action is needed.',
+    });
     await Promise.allSettled(
       emailTargets.map((m) =>
         sendEmail({
           to: m.record.value.email,
           subject: `${title} — call scheduled`,
-          html: `<p><strong>${safeTitle}</strong> has been scheduled.</p><p><strong>When:</strong> ${new Date(finalTime).toUTCString()} (${durationMinutes} min)</p><p>A calendar invite is attached.</p>`,
+          ...composed,
           attachments: [{ filename: 'invite.ics', content: icsBase64 }],
         })
       )

--- a/server/src/routes/polls.js
+++ b/server/src/routes/polls.js
@@ -4,6 +4,7 @@ import { validatePollCreate, validatePollUpdate, validateGoogleEvent } from '../
 import { indexPoll, updatePollStatus, updatePollCommunity, removePoll, listByCommunity } from '../lib/pollIndex.js';
 import { generateIcs } from '../lib/ical.js';
 import { sendEmail } from '../lib/email.js';
+import { composeEmail } from '../lib/email-template.js';
 import { deleteOpenMeetEvent } from './openmeet.js';
 import { fetchPollResponses } from '../lib/responseReads.js';
 import { publishToCommunityFeed } from '../mcp/tools.js';
@@ -282,12 +283,30 @@ router.put('/:did/:rkey/finalize', requireAuth, async (req, res, next) => {
     const clientEmails = Array.isArray(notifyEmails) ? notifyEmails : [];
     const emailList = [...new Set([...responseEmails, ...clientEmails])];
     if (emailList.length > 0) {
+      const whenStr = new Date(updatedRecord.finalTime).toLocaleString('en-US', {
+        dateStyle: 'full',
+        timeStyle: 'short',
+        timeZone: updatedRecord.timezone || 'UTC',
+      });
+      // Composed once, not per recipient: the body is identical for everyone.
+      const composed = composeEmail({
+        heading: `${updatedRecord.title} is scheduled`,
+        paragraphs: [
+          `${whenStr}, for ${updatedRecord.finalDuration} minutes.`,
+          updatedRecord.description,
+          participants.length > 0 ? `Who answered the poll: ${participants.join(', ')}.` : null,
+          'A calendar invite is attached, so this should appear in your calendar automatically.',
+        ],
+        action: { label: 'View the poll', url: pollUrl },
+        footer:
+          'You are receiving this because you answered this poll or were added to its notification list. No action is needed.',
+      });
       await Promise.allSettled(
         emailList.map((email) =>
           sendEmail({
             to: email,
             subject: `${updatedRecord.title} — time confirmed`,
-            html: `<p><strong>${updatedRecord.title}</strong> has been scheduled.</p>${updatedRecord.description ? `<p>${updatedRecord.description}</p>` : ''}<p><strong>When:</strong> ${new Date(updatedRecord.finalTime).toLocaleString('en-US', { dateStyle: 'full', timeStyle: 'short', timeZone: updatedRecord.timezone || 'UTC' })} (${updatedRecord.finalDuration} min)</p>${participants.length > 0 ? `<p><strong>Participants:</strong> ${participants.join(', ')}</p>` : ''}<p><a href="${pollUrl}">View poll</a></p><p>A calendar invite is attached.</p>`,
+            ...composed,
             attachments: [
               {
                 filename: 'invite.ics',
@@ -377,12 +396,24 @@ router.delete('/:did/:rkey/finalize', requireAuth, async (req, res, next) => {
         timeZone: snapshot.timezone || 'UTC',
       });
 
+      const composed = composeEmail({
+        heading: `${snapshot.title} is no longer scheduled`,
+        paragraphs: [
+          `The time that had been picked, ${whenStr}, is cancelled.`,
+          'Your calendar should remove it on its own, since a cancellation is attached.',
+          'The poll is open again, so you can change your availability if your options have shifted.',
+        ],
+        action: { label: 'Update your availability', url: pollUrl },
+        footer:
+          'You are receiving this because you answered this poll or were added to its notification list.',
+      });
+
       await Promise.allSettled(
         emailList.map((email) =>
           sendEmail({
             to: email,
             subject: `Cancelled: ${snapshot.title}`,
-            html: `<p><strong>${snapshot.title}</strong> has been unscheduled.</p><p>The previously-scheduled time (${whenStr}) is cancelled. Your calendar should remove it automatically.</p><p><a href="${pollUrl}">View poll</a> — the poll is open again and you can update your availability.</p>`,
+            ...composed,
             attachments: [
               {
                 filename: 'cancel.ics',

--- a/server/src/routes/responses.js
+++ b/server/src/routes/responses.js
@@ -4,6 +4,7 @@ import { getClient } from './auth.js';
 import { validateResponseCreate } from '../middleware/validate.js';
 import { incrementResponseCount } from '../lib/pollIndex.js';
 import { sendEmail } from '../lib/email.js';
+import { composeEmail } from '../lib/email-template.js';
 import {
   isServiceConfigured, serviceCreateRecord, servicePutRecord, serviceDeleteRecord, serviceGetRecord,
 } from '../lib/serviceSession.js';
@@ -118,10 +119,20 @@ router.post('/:did/:rkey/responses', validateResponseCreate, async (req, res, ne
         const poll = pollData.value;
         if (poll.notifyAfter && newCount >= poll.notifyAfter && poll.creatorEmail) {
           const viewUrl = `${process.env.CLIENT_URL || 'http://localhost:5173'}/poll/${did}/${rkey}`;
+          const plural = (n) => (n !== 1 ? 's' : '');
           await sendEmail({
             to: poll.creatorEmail,
-            subject: `${poll.title} — ${newCount} response${newCount !== 1 ? 's' : ''} received`,
-            html: `<p>Your poll <strong>${poll.title}</strong> has reached ${newCount} response${newCount !== 1 ? 's' : ''}.</p><p><a href="${viewUrl}">View responses</a></p>`,
+            subject: `${poll.title} — ${newCount} response${plural(newCount)} received`,
+            ...composeEmail({
+              heading: `${poll.title} has ${newCount} response${plural(newCount)}`,
+              paragraphs: [
+                `You asked to hear once this poll reached ${poll.notifyAfter} response${plural(poll.notifyAfter)}. It is at ${newCount}.`,
+                'You can pick a time now, or leave the poll open and wait for more people to answer.',
+              ],
+              action: { label: 'See who is available', url: viewUrl },
+              footer:
+                'You are receiving this because you created this poll and asked to be notified at a response count.',
+            }),
           });
         }
       }

--- a/server/test/email-template.test.js
+++ b/server/test/email-template.test.js
@@ -1,0 +1,78 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { composeEmail } from '../src/lib/email-template.js';
+import { sendEmail } from '../src/lib/email.js';
+
+// A poll title is user-supplied and ends up in an email body. Four of the five
+// call sites interpolated it into HTML without escaping before avails#146.
+const HOSTILE = `Team <script>alert("x")</script> & "friends" it's`;
+
+test('escapes user-supplied text in the HTML part', () => {
+  const { html } = composeEmail({
+    heading: HOSTILE,
+    paragraphs: [HOSTILE],
+    action: { label: HOSTILE, url: 'https://example.test/p?a=1&b=2' },
+    footer: HOSTILE,
+  });
+  assert.ok(!html.includes('<script>'), 'raw <script> reached the HTML');
+  assert.ok(!html.includes('alert("x")'), 'unescaped quotes reached the HTML');
+  assert.ok(html.includes('&lt;script&gt;'), 'expected escaped markup');
+  assert.ok(html.includes('a=1&amp;b=2'), 'ampersand in the URL should be escaped');
+});
+
+test('leaves the plain-text part unescaped and readable', () => {
+  const { text } = composeEmail({
+    heading: HOSTILE,
+    paragraphs: ['Plain sentence.'],
+    action: null,
+    footer: 'Why you got this.',
+  });
+  // Escaping is an HTML concern. Entities in a text/plain part would show up
+  // literally as "&lt;" in the reader's client.
+  assert.ok(text.includes(HOSTILE), 'text part should carry the original string');
+  assert.ok(!text.includes('&lt;'), 'text part must not contain HTML entities');
+});
+
+test('always produces both parts, and the text part carries the link', () => {
+  const url = 'https://avails.citizeninfra.org/poll/did:plc:abc/xyz';
+  const { html, text } = composeEmail({
+    heading: 'Standup is scheduled',
+    paragraphs: ['Tuesday 12 August, 14:00, for 30 minutes.'],
+    action: { label: 'View the poll', url },
+    footer: 'You answered this poll.',
+  });
+  assert.ok(html.length > 0 && text.length > 0);
+  assert.ok(text.includes(url), 'a text reader must still be able to reach the link');
+  assert.ok(html.includes('<!doctype html>'), 'expected a real document, not a fragment');
+});
+
+test('omits the action block when there is nowhere to send the reader', () => {
+  // schedule_call books from standing availability, so there is no poll page.
+  const { html, text } = composeEmail({
+    heading: 'Call is scheduled',
+    paragraphs: ['Tuesday, for 30 minutes.'],
+    action: null,
+    footer: 'Your standing availability covered this time.',
+  });
+  assert.ok(!html.includes('<a '), 'no link expected');
+  assert.ok(!text.includes('http'), 'no link expected in the text part either');
+});
+
+test('drops empty paragraphs so optional fields do not leave blank lines', () => {
+  const { html, text } = composeEmail({
+    heading: 'H',
+    paragraphs: ['first', null, undefined, '', 'second'],
+    footer: 'F',
+  });
+  assert.equal(html.match(/<p style="margin:0 0 14px 0/g).length, 2);
+  assert.ok(!text.includes('\n\n\n'), 'no triple newline from a dropped paragraph');
+});
+
+test('sendEmail refuses an HTML-only message', async () => {
+  // The guard must fire without RESEND_API_KEY set, otherwise it is unreachable
+  // in development and only shows up in production.
+  await assert.rejects(
+    () => sendEmail({ to: 'a@example.test', subject: 's', html: '<p>x</p>' }),
+    /text part is required/
+  );
+});


### PR DESCRIPTION
Closes #146.

## Why now

Both problems in #146 got worse on 2026-08-02, when Avails moved to `noreply@citizeninfra.org`. A domain registered that morning has no sending reputation to absorb an HTML-only, link-dominant message, and that shape is what Gmail filters on regardless of DKIM, SPF or DMARC. Message shape is the only lever left.

## One correction to the issue

It reported **two** unescaped title interpolations. There were **four** of five: `polls.js` (both paths), `responses.js`, and the MCP finalize path. Only `schedule_call` escaped. Rather than patch four sites, `composeEmail()` takes plain text and escapes it itself, so the class is closed by construction and a fifth site cannot reintroduce it.

## What changed

**`server/src/lib/email-template.js`** (new). One composer producing the HTML and text parts together from the same plain-text input. Callers never write HTML, so escaping cannot be forgotten and a message without a text part cannot be written.

**`sendEmail()`** now requires `text` and throws without it. The check sits **before** the missing-`RESEND_API_KEY` early return, deliberately: below it, the guard would be unreachable in development and would only ever fire in production.

**Content is self-sufficient.** The time, duration and who answered are stated in the body. A reader gets the answer without clicking, and the link stops being most of the message. Text part of a real render:

```
Thursday planning call is scheduled

Tuesday, August 12, 2026 at 2:00 PM, for 45 minutes.

Who answered the poll: Sam Okonkwo, Priya Raman, Jo Bergstrom, Marta Silva, Chen Wei.

A calendar invite is attached, so this should appear in your calendar automatically.

View the poll: https://avails.citizeninfra.org/poll/did:plc:xk2/3lm

--
You are receiving this because you answered this poll or were added to its
notification list. No action is needed.
```

**`tools.js` loses its local `escapeHtml`** — it only ever served email and is now dead. `lib/og.js` keeps its own for OG meta tags, a different concern. Net one fewer duplicate.

## Design

Light-brand register for email, per `DESIGN.md`: Paper Cream ground, hairline rule, "avails" as text, one link, flat, no images, no filled button. Deliberately *not* the full app treatment: a heavier promotional layout is measurably worse for inbox placement, which is the entire point of the change.

**One documented exception.** Body links use Deep Teal `#0f766e`, not Gather Teal `#0d9488`. Gather Teal on Paper Cream measures **3.56:1** — fine for large text and UI, below AA's 4.5:1 for normal text, and an email body link is normal text. Deep Teal is **5.28:1**. `DESIGN.md` §2 previously said Deep Teal never appears alone, so the carve-out is written into the file rather than left as an undocumented drift.

## Verification

- 164 server tests pass, including 6 new ones covering escaping, the text/HTML pair, the no-link path, dropped empty paragraphs, and the `sendEmail` guard.
- The escaping test uses a hostile title (`<script>`, quotes, ampersand) and asserts the HTML part escapes it **and** the text part does not, since entities in `text/plain` would render literally.
- Rendered at true 360px and 640px widths in a headless browser. Worth noting for anyone repeating it: `--window-size` is not the layout viewport in headless Edge — 420 produced a 518px layout here — so the email is rendered inside a fixed-width iframe rather than by sizing the window.

## Not covered

`lib/og.js` still has its own `escapeHtml`. Left alone deliberately; folding it in would mean touching an unrelated module in an email PR.
