### PR TITLE
feat(mcp): delete_poll — an agent could create polls but not clean up (#148)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,4 +85,4 @@ Railway (single service, Nixpacks builder). Custom domain: avails.zhgnv.com.
 
 ## Reference
 
-Read when working on internals: [Architecture & gotchas](docs/architecture.md) — data model, OAuth flow, components, MCP endpoint (ten tools, including `schedule_call` — books a call from standing availability, no poll — and `publish_to_community_feed` — publish/unpublish a poll to its community's My Community feed, creator + membership gated), standing availability, OpenMeet integration, known debts.
+Read when working on internals: [Architecture & gotchas](docs/architecture.md) — data model, OAuth flow, components, MCP endpoint (eleven tools, including `delete_poll` — creator-only, allows finalized polls because deleting is error correction, and deliberately leaves service-repo responses alone exactly as the REST delete does (#148) — and `schedule_call` — books a call from standing availability, no poll — and `publish_to_community_feed` — publish/unpublish a poll to its community's My Community feed, creator + membership gated), standing availability, OpenMeet integration, known debts.

--- a/server/src/mcp/tools.js
+++ b/server/src/mcp/tools.js
@@ -1,4 +1,4 @@
-import { indexPoll, updatePollStatus, updatePollPublished, listByCommunity } from '../lib/pollIndex.js';
+import { indexPoll, updatePollStatus, updatePollPublished, listByCommunity, removePoll } from '../lib/pollIndex.js';
 import { generateIcs } from '../lib/ical.js';
 import { sendEmail } from '../lib/email.js';
 import { composeEmail } from '../lib/email-template.js';
@@ -212,6 +212,21 @@ const TOOL_DEFINITIONS = [
         hideResponsesUntilSubmit: {
           type: 'boolean',
           description: 'If true, respondents see no other responses on the grid until they submit their own',
+        },
+      },
+      required: ['rkey'],
+    },
+  },
+  {
+    name: 'delete_poll',
+    description:
+      "Delete one of your own polls. Removes the poll record from your PDS and drops it from the community index. Works on finalized polls too — this is error correction. Responses already collected are NOT deleted; they live in avails' own repo and simply stop being reachable.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        rkey: {
+          type: 'string',
+          description: 'Record key of the poll to delete',
         },
       },
       required: ['rkey'],
@@ -514,6 +529,58 @@ async function updatePoll(args, authContext) {
   }
 
   return JSON.stringify({ ok: true, poll: updatedRecord, url: pollUrl(did, rkey) });
+}
+
+// delete_poll (#148): an agent could create polls through this surface but never
+// remove one, so every throwaway poll was permanent litter in the creator's repo
+// until a human opened the UI. That asymmetry made verifying anything leave
+// residue by construction.
+//
+// The rkey is resolved against authContext.did, so a caller can only ever delete
+// out of their own repo — the creator check the REST route performs explicitly
+// (`req.userDid !== did` -> 403) is structural here rather than conditional.
+//
+// Unlike update_poll this does NOT refuse a finalized poll. The REST delete
+// allows it, and two delete paths for the same object disagreeing about what is
+// deletable would be worse than either rule: deleting is error correction, and
+// the creator's judgement governs.
+//
+// Responses are deliberately left alone. Since #42 they live in avails' own
+// repo, not the creator's, so removing the poll record cannot reach them —
+// exactly as the REST delete already behaves. fetchPollResponses filters by
+// `pollUri.endsWith('/<rkey>')`, so they become unreachable rather than
+// corrupting anything. Whether both paths should sweep them is a real question
+// and belongs to its own change, not to one of the two callers.
+async function deletePoll(args, authContext) {
+  if (!authContext) throw new Error('AUTH_REQUIRED');
+  if (!authContext.oauthSession) throw new Error('AUTH_REQUIRED');
+
+  const { rkey } = args;
+  if (!rkey) throw new Error('rkey is required');
+
+  const did = authContext.did;
+  const pds = await resolvePds(did);
+
+  // Read first so a wrong rkey is a clear "not found" rather than a silent
+  // success — deleteRecord does not distinguish the two.
+  const getRes = await fetch(
+    `${pds}/xrpc/com.atproto.repo.getRecord?repo=${encodeURIComponent(did)}&collection=${encodeURIComponent(POLL_COLLECTION)}&rkey=${encodeURIComponent(rkey)}`
+  );
+  if (!getRes.ok) throw new Error(`Poll not found: ${getRes.status}`);
+  const existing = await getRes.json();
+
+  await xrpcCall(authContext.oauthSession, 'com.atproto.repo.deleteRecord', {
+    repo: did,
+    collection: POLL_COLLECTION,
+    rkey,
+  });
+
+  removePoll(did, rkey);
+
+  return JSON.stringify({
+    ok: true,
+    deleted: { did, rkey, title: existing.value?.title || null },
+  });
 }
 
 async function listMyPolls(_args, authContext) {
@@ -1140,6 +1207,8 @@ export async function callTool(name, args, authContext) {
       return createPoll(args, authContext);
     case 'update_poll':
       return updatePoll(args, authContext);
+    case 'delete_poll':
+      return deletePoll(args, authContext);
     case 'list_my_polls':
       return listMyPolls(args, authContext);
     case 'schedule':

--- a/server/test/mcp-delete-poll.test.js
+++ b/server/test/mcp-delete-poll.test.js
@@ -1,0 +1,100 @@
+// delete_poll (#148). An agent could create polls through the MCP but never
+// remove one, so verifying anything left permanent litter in the creator's repo.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+let fetchImpl;
+globalThis.fetch = (...a) => fetchImpl(...a);
+
+const { callTool, listTools } = await import('../src/mcp/tools.js');
+
+// The real session exposes fetchHandler(pathname, init) — it owns DPoP and token
+// refresh — so xrpcCall goes through it rather than global fetch. Record what it
+// is asked to do.
+const xrpcCalls = [];
+const AUTH = {
+  did: 'did:plc:creator',
+  oauthSession: {
+    fetchHandler: async (pathname, init) => {
+      xrpcCalls.push({ pathname, body: JSON.parse(init.body) });
+      return { ok: true, status: 200, json: async () => ({}), text: async () => '' };
+    },
+  },
+};
+const PDS = 'https://pds.example';
+
+// plc.directory resolution + a getRecord hit, with everything else recorded.
+function pdsFetch({ record = { title: 'Team sync' }, found = true, calls = [] } = {}) {
+  return async (url, opts) => {
+    const u = String(url);
+    calls.push({ url: u, body: opts?.body ? JSON.parse(opts.body) : null });
+    if (u.startsWith('https://plc.directory/')) {
+      return {
+        ok: true,
+        json: async () => ({ service: [{ id: '#atproto_pds', serviceEndpoint: PDS }] }),
+      };
+    }
+    if (u.includes('getRecord')) {
+      if (!found) return { ok: false, status: 404, text: async () => 'RecordNotFound' };
+      return { ok: true, json: async () => ({ value: record, cid: 'bafy1' }) };
+    }
+    return { ok: true, json: async () => ({}) };
+  };
+}
+
+describe('delete_poll', () => {
+  it('is advertised so an agent can discover it', () => {
+    const tool = listTools().find((t) => t.name === 'delete_poll');
+    assert.ok(tool, 'delete_poll must be in TOOL_DEFINITIONS');
+    assert.deepEqual(tool.inputSchema.required, ['rkey']);
+  });
+
+  it('deletes the poll from the caller\'s own repo', async () => {
+    const calls = [];
+    fetchImpl = pdsFetch({ calls });
+
+    const out = JSON.parse(await callTool('delete_poll', { rkey: 'abc123' }, AUTH));
+    assert.equal(out.ok, true);
+    assert.deepEqual(out.deleted, { did: 'did:plc:creator', rkey: 'abc123', title: 'Team sync' });
+
+    const del = xrpcCalls.find((c) => c.pathname.includes('deleteRecord'));
+    assert.ok(del, 'must call com.atproto.repo.deleteRecord');
+    assert.equal(del.body.repo, 'did:plc:creator');
+    assert.equal(del.body.rkey, 'abc123');
+    assert.equal(del.body.collection, 'chat.avails.scheduling.poll');
+  });
+
+  it('reads the record first so a wrong rkey is "not found", not a silent success', async () => {
+    const calls = [];
+    fetchImpl = pdsFetch({ found: false, calls });
+
+    const before = xrpcCalls.length;
+    await assert.rejects(() => callTool('delete_poll', { rkey: 'nope' }, AUTH), /Poll not found/);
+    assert.equal(xrpcCalls.length, before,
+      'must not delete when the record could not be read');
+  });
+
+  it('deletes a finalized poll too — this is error correction, and the REST route allows it', async () => {
+    const calls = [];
+    fetchImpl = pdsFetch({ record: { title: 'Booked already', finalTime: '2026-08-11T14:00' }, calls });
+
+    const before = xrpcCalls.length;
+    const out = JSON.parse(await callTool('delete_poll', { rkey: 'fin1' }, AUTH));
+    assert.equal(out.ok, true);
+    assert.ok(xrpcCalls.length > before, 'must have issued a deleteRecord');
+  });
+
+  it('requires auth, and never touches the network without it', async () => {
+    let touched = false;
+    fetchImpl = async () => { touched = true; return { ok: true, json: async () => ({}) }; };
+
+    await assert.rejects(() => callTool('delete_poll', { rkey: 'x' }, null), /AUTH_REQUIRED/);
+    await assert.rejects(() => callTool('delete_poll', { rkey: 'x' }, { did: 'did:plc:creator' }), /AUTH_REQUIRED/);
+    assert.equal(touched, false);
+  });
+
+  it('requires an rkey', async () => {
+    fetchImpl = async () => { throw new Error('should not fetch'); };
+    await assert.rejects(() => callTool('delete_poll', {}, AUTH), /rkey is required/);
+  });
+});


### PR DESCRIPTION
Closes #148.

The MCP had `create_poll` and `update_poll` but no delete, and the REST delete (`polls.js:483`) is `requireAuth` — a browser OAuth session, unreachable with an MCP token. So an agent could create polls in a user's PDS and had no way to remove them: every throwaway poll was permanent litter until a human opened the UI.

That asymmetry makes verification leave residue by construction, which is a quiet disincentive to verifying at all. It surfaced while confirming #42 still worked after the `AVAILS_SERVICE_APP_PASSWORD` rotation — the response record deleted cleanly and was confirmed gone with `RecordNotFound`; only the poll couldn't be.

## Three decisions

**Authorization is structural, not conditional.** The `rkey` resolves against `authContext.did`, so a caller can only ever delete out of their own repo. The REST route needs an explicit `req.userDid !== did` check because the DID is a URL parameter there; here there is nothing to compare.

**It reads the record first.** `deleteRecord` does not distinguish a missing rkey from a successful delete, so without the read a typo would report `ok: true` and the caller would believe something was removed. Pinned by a test asserting no `deleteRecord` is issued when the read fails.

**It allows finalized polls, unlike `update_poll`.** #148 suggested refusing them, but reading the REST delete showed it allows them — and two delete paths for the same object disagreeing about what is deletable is worse than either rule on its own. Deleting is error correction and the creator's judgement governs; editing a committed record is a different act.

## Responses are deliberately untouched

Since #42 responses live in **avails' own repo**, not the creator's, so removing the poll record cannot reach them. The REST delete already behaves this way — this change doesn't introduce the orphaning, it inherits it.

`fetchPollResponses` filters by `pollUri.endsWith('/<rkey>')`, so orphans become unreachable rather than corrupting anything. Whether *both* paths should sweep them is a real question, and #148 flags it as the more interesting half; it belongs in its own change rather than being answered by one of the two callers.

## Verification

**170 tests, 6 new, all passing.** Syntax check clean.

The tests use a correctly-shaped `oauthSession` exposing `fetchHandler(pathname, init)` rather than a bare stub — the first version passed a fake object and failed with `oauthSession.fetchHandler is not a function`, which is worth noting because it's the shape every other authenticated tool goes through.

Covered: the tool is discoverable in `listTools()`, deletes from the caller's own repo with the right collection and rkey, refuses a missing rkey without deleting, deletes a finalized poll, requires auth without touching the network, and requires an rkey.

## After this deploys

The smoke-test poll left behind by the #42 verification can finally be removed:

`at://did:plc:7t3rryg4ck5ifux2jokclglk/chat.avails.scheduling.poll/3ms5ekhnzon2n`