### PR TITLE
fix(mcp): persist the DID binding immediately, and log why auth fails

### DIFF
--- a/server/src/mcp/handler.js
+++ b/server/src/mcp/handler.js
@@ -25,8 +25,22 @@ async function extractAuthContext(req) {
     // mcp_client_id IS the client_id in the new RFC 7591 flow
     const clientId = claims.mcp_client_id || claims.client_id;
     const mcpClient = getClient(clientId);
-    if (!mcpClient) return null;
-    if (mcpClient.did !== claims.sub) return null;
+    // Both of these used to return null silently, so a valid, unexpired token
+    // being rejected looked identical to no token at all — the request just
+    // logged "unauthenticated" and the client reported "token expired". Say
+    // which one it was; the difference is a lost registration versus a lost DID
+    // binding, and they have different causes.
+    if (!mcpClient) {
+      console.warn(`MCP auth: no client registered for ${clientId} (token is valid) — registration lost?`);
+      return null;
+    }
+    if (mcpClient.did !== claims.sub) {
+      console.warn(
+        `MCP auth: client ${clientId} is bound to ${mcpClient.did === null ? 'no DID' : mcpClient.did}` +
+        `, token claims ${claims.sub} — DID binding lost or mismatched`
+      );
+      return null;
+    }
 
     // Get the canonical OAuth session from the ATProto client
     // This ensures correct DPoP key bindings (not a stale session reference)

--- a/server/src/mcp/oauth.js
+++ b/server/src/mcp/oauth.js
@@ -6,6 +6,7 @@ import { getClient as getOAuthClient } from '../routes/auth.js';
 import { createSession } from '../lib/sessionStore.js';
 import { registerClient, getClient, bindClientDid } from './clients.js';
 import { signToken } from './jwt.js';
+import { saveNow } from '../lib/persistence.js';
 
 const router = Router();
 
@@ -260,7 +261,7 @@ button:hover{background:#0b7f74}</style>
  * @param {string} handle - the authenticated user's handle
  * @returns {string|null} redirect URL for MCP client, or null
  */
-export function tryMcpCallback(state, oauthSession, did, handle) {
+export async function tryMcpCallback(state, oauthSession, did, handle) {
   const pending = pendingAuths.get(state);
   if (!pending) return null;
 
@@ -268,6 +269,14 @@ export function tryMcpCallback(state, oauthSession, did, handle) {
 
   // Bind DID to MCP client
   bindClientDid(pending.mcpClientId, did);
+
+  // Force the write instead of waiting for the 30s persistence tick. The DID
+  // bound above is exactly what extractAuthContext compares `claims.sub`
+  // against, and both of its failure paths return null silently — so a bind
+  // lost to a restart before the next flush comes back as `did: null` and every
+  // later request from that client is treated as unauthenticated, forever, with
+  // nothing in the logs. Paying one small write per authorization closes that.
+  await saveNow();
 
   // Issue one-time auth code
   const code = crypto.randomBytes(32).toString('hex');

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -178,8 +178,8 @@ router.get('/callback', async (req, res, next) => {
     // Check if this callback is from an MCP OAuth flow
     const callbackState = params.get('state');
     const resultState = result.state;
-    const mcpRedirect = tryMcpCallback(resultState, session, did, handle)
-      || tryMcpCallback(callbackState, session, did, handle);
+    const mcpRedirect = (await tryMcpCallback(resultState, session, did, handle))
+      || (await tryMcpCallback(callbackState, session, did, handle));
     if (mcpRedirect) {
       return res.type('html').send(`<!DOCTYPE html>
 <html>

--- a/server/test/mcp-auth-persistence.test.js
+++ b/server/test/mcp-auth-persistence.test.js
@@ -1,0 +1,79 @@
+// The DID binding an MCP client acquires at OAuth completion is what
+// extractAuthContext compares every later token against. It used to be written
+// only by the 30s persistence tick, so a restart before the next flush restored
+// the client with `did: null` and every later request from that client was
+// silently treated as unauthenticated — no log, and the client reporting "token
+// expired" for a token still valid for another 22 hours.
+import { describe, it, mock, after } from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+
+let saveNowCalls = 0;
+mock.module('../src/lib/persistence.js', {
+  namedExports: {
+    saveNow: async () => { saveNowCalls++; },
+    registerStore: () => {},
+    markDirty: () => {},
+    startPersistence: async () => {},
+  },
+});
+
+// The route hands its internal state to the ATProto client's authorize(); that
+// is the only way to observe it, since pendingAuths is module-private.
+let capturedState = null;
+mock.module('../src/routes/auth.js', {
+  namedExports: {
+    getClient: async () => ({
+      authorize: async (_handle, opts) => { capturedState = opts.state; return 'https://pds.example/authorize'; },
+      restore: async () => null,
+    }),
+  },
+});
+
+const { getClient: getMcpClient } = await import('../src/mcp/clients.js');
+const oauthRouter = (await import('../src/mcp/oauth.js')).default;
+const { tryMcpCallback } = await import('../src/mcp/oauth.js');
+
+const app = express();
+app.use(express.json());
+app.use('/mcp', oauthRouter);
+const server = app.listen(0);
+const base = `http://127.0.0.1:${server.address().port}`;
+after(() => server.close());
+
+describe('MCP DID binding durability', () => {
+  it('flushes the binding to disk before handing back an auth code', async () => {
+    const reg = await (await fetch(`${base}/mcp/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ redirect_uris: ['http://127.0.0.1:9999/cb'], client_name: 'test client' }),
+    })).json();
+    assert.ok(reg.client_id, 'registration must return a client_id');
+
+    const qs = new URLSearchParams({
+      response_type: 'code',
+      client_id: reg.client_id,
+      redirect_uri: 'http://127.0.0.1:9999/cb',
+      state: 'client-state',
+      code_challenge: 'challenge',
+      handle: 'someone.test',
+    });
+    await fetch(`${base}/mcp/authorize?${qs}`, { redirect: 'manual' });
+    assert.ok(capturedState, 'the authorize route must have started an ATProto flow');
+
+    saveNowCalls = 0;
+    const redirect = await tryMcpCallback(capturedState, { fake: 'session' }, 'did:plc:someone', 'someone.test');
+
+    assert.ok(redirect, 'a pending MCP flow must produce a redirect');
+    assert.equal(getMcpClient(reg.client_id).did, 'did:plc:someone', 'the DID must be bound');
+    assert.equal(saveNowCalls, 1,
+      'the binding must be persisted immediately, not left to the 30s tick');
+  });
+
+  it('does nothing and persists nothing for a state that is not an MCP flow', async () => {
+    saveNowCalls = 0;
+    const out = await tryMcpCallback('not-a-pending-state', {}, 'did:plc:x', 'x.test');
+    assert.equal(out, null);
+    assert.equal(saveNowCalls, 0);
+  });
+});


### PR DESCRIPTION
## What happened

The avails MCP token stopped working twice in one session, both times shortly after a redeploy. Claude Code reported "token expired" for a token that was **valid for another 22 hours**.

Evidence gathered before changing anything:

- JWT lifetime is 24h and matches what the client recorded; the rejected token was ~2h old. **Not time expiry.**
- **No `MCP auth extraction failed` in the logs**, so `verifyToken` never threw — the JWT was valid and correctly signed.
- Railway HTTP logs show four `POST /mcp 401` between the deploy and the re-authorization, and none after.

That leaves the two paths in `extractAuthContext` that return `null` **silently**: `getClient(clientId)` missing, or `mcpClient.did !== claims.sub`.

## The bug

`bindClientDid` — which sets the very DID `extractAuthContext` compares `claims.sub` against — only calls `markDirty()`. The actual write waits for the **30-second interval flush** in `lib/persistence.js`.

So a binding lost to a restart before that flush comes back as `did: null`. Every later request from that client then fails the comparison, silently, **permanently** — nothing rebinds it, and the client has a token it believes is valid for hours.

`tryMcpCallback` is now `async` and awaits `saveNow()` after binding, so the binding is durable before the authorization code is handed back. Its single caller is already an async route handler.

## The second, arguably worse half

Both rejection paths returned `null` with no log, which made a valid-token rejection **indistinguishable from sending no token at all** — the request logged `unauthenticated` and the client said "token expired".

Diagnosing one occurrence took Railway deploy logs, an HTTP-status timeline, a JWT decode, and reading three source files. It should have taken one log line. Both paths now warn and say *which* fired, because a lost registration and a lost DID binding have different causes and different fixes.

## Honest limit on the diagnosis

The authorization in this session happened roughly **10 hours** before the deploy that broke it — far longer than the 30-second window. So plain flush-lag does not fully explain *this* instance, and I could not read the Railway volume to check whether the client came back missing or came back unbound.

What is established: the JWT was valid, the rejection was silent, it was deploy-adjacent, and the persistence design has a real loss window with no logging on either failure path. This change closes the window and makes the next occurrence self-diagnosing in one line rather than an investigation. If it recurs, the new warning says immediately which path it took.

Worth noting `loadAll` merges into the in-memory map rather than replacing it, and `saveAll` writes the whole map — so a process holding stale state can also overwrite newer state. Not addressed here; flagged because it is the other way this data can go backwards.

## Verification

**172 tests** (2 new), syntax check clean.

The new test drives the real `/mcp/register` → `/mcp/authorize` → `tryMcpCallback` path against a live express instance, capturing the module-private internal state via the mocked ATProto client's `authorize()` — the only seam that exposes it.

Proven to discriminate: reverting `await saveNow()` turns exactly one test red, then restored.