### PR TITLE
Split the CORS allowlist out of CLIENT_URL (#151)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,8 @@ Railway (single service, Nixpacks builder). Custom domain: avails.zhgnv.com.
 - `AVAILS_SERVICE_PDS` — optional; the account's PDS host for login (default `https://bsky.social`)
 - `TELEGRAM_BOT_TOKEN` — Avails bot token for share_poll
 - `RESEND_API_KEY` — email service
-- `CLIENT_URL` — deployed URL (for redirects and email links)
+- `CLIENT_URL` — deployed URL (for redirects and email links). No longer the CORS allowlist — see `CORS_ORIGINS`.
+- `CORS_ORIGINS` — optional, comma-separated extra browser origins allowed to call the API (#151). `CLIENT_URL` is always allowed, so leaving this unset preserves the previous single-origin behaviour. During a domain migration, point `CLIENT_URL` at the new host immediately (redirects and email links should move at once) and list the old host here until nothing calls it.
 - `DATA_DIR` — Railway volume mount path (`/data`)
 - `VITE_GOOGLE_CLIENT_ID` — optional, for Google Calendar integration: busy-time overlay, event create on schedule, event cancel on unschedule, writable-calendar picker (baked into client build)
 - `OPENMEET_TENANT_ID` — OpenMeet instance tenant (default: `lsdfaopkljdfs`)

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,5 +1,10 @@
 PORT=3000
 CLIENT_URL=http://localhost:5173
+# Extra browser origins allowed to call the API, comma-separated. CLIENT_URL is
+# always allowed and does not need repeating here. Use this during a domain
+# migration to keep the old host working while CLIENT_URL already points at the
+# new one (#151).
+CORS_ORIGINS=
 ATPROTO_CLIENT_ID=https://avails.zhgnv.com/api/auth/client-metadata-v4.json
 ATPROTO_REDIRECT_URI=https://avails.zhgnv.com/api/auth/callback
 SESSION_SECRET=change-me-to-random-string

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -11,6 +11,7 @@ import responseRoutes from './routes/responses.js';
 import availabilityRoutes from './routes/availability.js';
 import communityRoutes from './routes/communities.js';
 import openmeetRoutes from './routes/openmeet.js';
+import { corsOriginCheck } from './lib/corsOrigins.js';
 import { startPersistence, markDirty, saveNow } from './lib/persistence.js';
 import { backfillCommunityFeedPublished } from './lib/pollIndex.js';
 import { restoreOAuthSessions, sessions } from './lib/sessionStore.js';
@@ -38,7 +39,7 @@ const PORT = process.env.PORT || 3000;
 app.set('trust proxy', 1);
 
 app.use(cors({
-  origin: process.env.CLIENT_URL || 'http://localhost:5173',
+  origin: corsOriginCheck,
   credentials: true,
 }));
 app.use(express.json());

--- a/server/src/lib/corsOrigins.js
+++ b/server/src/lib/corsOrigins.js
@@ -1,0 +1,52 @@
+// The CORS allowlist, split out from CLIENT_URL (#151).
+//
+// CLIENT_URL keeps its other two jobs — redirect targets and links in outbound
+// email — and both want the NEW host the moment the migration starts. CORS
+// wants to accept the OLD one as well until every caller has moved. One string
+// cannot hold both answers, so whichever value you pick is wrong for one job.
+//
+// Same shape as community-admin's CA_ACCEPTED_DIDS (community-admin#99) and the
+// MC_EXTENSION_REDIRECT allowlist (community-admin#110): the server accepts a
+// list while clients move at their own pace, so there is no cutover moment.
+// Drop the old entry from CORS_ORIGINS once nothing calls it.
+
+// Origin headers never carry a trailing slash or a path, but CLIENT_URL is
+// hand-written and regularly does ("https://avails.citizeninfra.org/"), which
+// would otherwise silently never match any request. Comparing `.origin` rather
+// than the raw string is what fixes that: it is scheme + host + port and nothing
+// else, so the two spellings collapse to one value.
+function normalize(value) {
+  const trimmed = String(value || '').trim();
+  if (!trimmed) return '';
+  try {
+    return new URL(trimmed).origin;
+  } catch {
+    // Not a URL at all — a typo'd entry. Return it as written so it simply
+    // fails to match, rather than throwing on every request.
+    return trimmed;
+  }
+}
+
+// CLIENT_URL is always allowed, so a deploy that never sets CORS_ORIGINS behaves
+// exactly as it did before this change.
+export function corsOrigins() {
+  const extra = (process.env.CORS_ORIGINS || '')
+    .split(',')
+    .map(normalize)
+    .filter(Boolean);
+  const client = normalize(process.env.CLIENT_URL || 'http://localhost:5173');
+  return [...new Set([client, ...extra].filter(Boolean))];
+}
+
+// The `cors` package's origin callback. Passing a function rather than a fixed
+// string is what makes the `vary: Origin` header true: the allowed origin is now
+// echoed from the request instead of being one constant sent to every caller.
+export function corsOriginCheck(origin, callback) {
+  // No Origin header: same-origin navigation, curl, or a server-to-server call.
+  // CORS does not apply, and the avails web app itself arrives this way because
+  // it is served from the same Railway service as the API.
+  if (!origin) return callback(null, true);
+  // `false` omits the header and lets the browser refuse. Calling back with an
+  // Error would turn a routine cross-origin request into a 500 instead.
+  callback(null, corsOrigins().includes(normalize(origin)));
+}

--- a/server/test/corsOrigins.test.js
+++ b/server/test/corsOrigins.test.js
@@ -1,0 +1,68 @@
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { corsOrigins, corsOriginCheck } from '../src/lib/corsOrigins.js';
+
+const OLD = 'https://avails.zhgnv.com';
+const NEW = 'https://avails.citizeninfra.org';
+
+// The functions read process.env on every call, so each test sets its own world.
+beforeEach(() => {
+  delete process.env.CLIENT_URL;
+  delete process.env.CORS_ORIGINS;
+});
+
+// Calls the middleware callback synchronously and returns what cors would receive.
+function check(origin) {
+  let result;
+  corsOriginCheck(origin, (err, allowed) => {
+    assert.equal(err, null, 'the callback must never receive an Error');
+    result = allowed;
+  });
+  return result;
+}
+
+test('CLIENT_URL alone behaves exactly as before this change', () => {
+  process.env.CLIENT_URL = OLD;
+  assert.deepEqual(corsOrigins(), [OLD]);
+  assert.equal(check(OLD), true);
+});
+
+test('both migration hosts are accepted at once — the point of the issue', () => {
+  process.env.CLIENT_URL = NEW; // redirects and email links move immediately
+  process.env.CORS_ORIGINS = OLD; // the old host keeps working meanwhile
+  assert.equal(check(NEW), true);
+  assert.equal(check(OLD), true);
+});
+
+test('an unlisted origin is refused with false, not an Error', () => {
+  process.env.CLIENT_URL = NEW;
+  // Calling back with an Error turns a routine cross-origin request into a 500.
+  // `false` omits the header and lets the browser do the refusing.
+  assert.equal(check('https://example.test'), false);
+});
+
+test('a request with no Origin header is allowed through', () => {
+  process.env.CLIENT_URL = NEW;
+  // curl, server-to-server, and the avails web app itself, which is served from
+  // the same Railway service as the API and so is always same-origin.
+  assert.equal(check(undefined), true);
+});
+
+test('a trailing slash in config still matches a real Origin header', () => {
+  // Origin headers never carry one; hand-written env values regularly do.
+  process.env.CLIENT_URL = `${NEW}/`;
+  process.env.CORS_ORIGINS = `${OLD}/`;
+  assert.equal(check(NEW), true);
+  assert.equal(check(OLD), true);
+});
+
+test('the list is whitespace-tolerant and de-duplicated', () => {
+  process.env.CLIENT_URL = NEW;
+  process.env.CORS_ORIGINS = ` ${OLD} , ${NEW} ,, `;
+  assert.deepEqual(corsOrigins(), [NEW, OLD]);
+});
+
+test('an unset CLIENT_URL falls back to the vite dev server', () => {
+  assert.deepEqual(corsOrigins(), ['http://localhost:5173']);
+  assert.equal(check('http://localhost:5173'), true);
+});


### PR DESCRIPTION
Closes #151.

## What changed

`CLIENT_URL` was doing three unrelated jobs: the CORS allow-origin, redirect targets, and links in outbound email. During a domain migration those want different values at the same moment — redirects and email should point at the new host immediately, while CORS must keep accepting the old one until every caller has moved. One string cannot hold both answers.

- **`CORS_ORIGINS`** — new, comma-separated extra origins. `CLIENT_URL` stays allowed unconditionally, so **a deploy that never sets this behaves exactly as before**.
- `cors({ origin })` now takes a function, so the allowed origin is echoed from the request instead of one constant being sent to every caller. That makes the `vary: Origin` header the `cors` package already emits true rather than decorative.

Third instance of this shape in the ecosystem — `CA_ACCEPTED_DIDS` (community-admin#99) and the `MC_EXTENSION_REDIRECT` allowlist (community-admin#110) were both fixed by having the server accept a list while clients move at their own pace. No cutover moment.

## Two decisions worth reviewing

**Denial calls back `false`, not an `Error`.** `false` omits the header and lets the browser refuse; an `Error` would turn a routine cross-origin request into a 500.

**Origins compare by `URL.origin`.** A hand-written trailing slash in config (`https://avails.citizeninfra.org/`) still matches a real `Origin` header, which never has one. Without this the configured value would silently never match.

## Tests

7 new tests in `server/test/corsOrigins.test.js`; full suite **179 pass / 0 fail**.

Mutation-checked — each mutation was applied to the implementation and the suite re-run:

| Mutation | Tests failing |
|---|---|
| always allow any origin | 3 |
| ignore `CORS_ORIGINS` entirely | 7 |
| call back an `Error` instead of `false` | 11 |
| drop `.origin` normalising | 3 |

The first run of that table had a fifth row that caught **nothing**: a `replace(/\/+$/, &#39;&#39;)` in `normalize()` was dead code, because `new URL(x).origin` already drops the trailing slash. The line is removed and the comment now credits the mechanism that actually does the work.

## Not in this PR

The `avails.zhgnv.com` strings in `.env.example`&#39;s OAuth entries, the client, and the docs belong to #150, whose OAuth half needs the deliberate client-metadata version bump. Left alone.

## Deploying

Merging alone changes nothing at runtime. Set **only** this on Railway for now:

```
CORS_ORIGINS=https://avails.citizeninfra.org
```

**Leave `CLIENT_URL` on `https://avails.zhgnv.com`.** An earlier version of this description said to flip it to the new host at the same time. That is wrong and would break sign-in:

`ATPROTO_REDIRECT_URI` still points at `https://avails.zhgnv.com/api/auth/callback`, so the OAuth callback is served by the **old** host. That handler sets `avails_session` via `res.cookie(...)` with no `domain`, which makes it host-only, and then redirects to `CLIENT_URL`. Point `CLIENT_URL` at the new host and the user lands on `avails.citizeninfra.org` carrying a cookie scoped to `avails.zhgnv.com` — signed out, with nothing logged and no error shown.

`CLIENT_URL` moves in #150, together with `ATPROTO_CLIENT_ID` and `ATPROTO_REDIRECT_URI` and the client-metadata version bump, which is exactly why that issue calls the OAuth host migration a deliberate step rather than a find-and-replace. At that point the two values swap: `CLIENT_URL` becomes the new host and `CORS_ORIGINS` holds the old one until nothing calls it.
