### PR TITLE
schedule_call now requires authentication (#149)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ Railway (single service, Nixpacks builder). Custom domain: avails.zhgnv.com.
 - `OPENMEET_TENANT_ID` — OpenMeet instance tenant (default: `lsdfaopkljdfs`)
 - `CA_MEMBERSHIP_URL` — community-admin base URL; `share_poll` gates on membership via `GET /api/memberships` (S4). A trailing slash is stripped in code.
 - `CA_CONFIG_SECRET` — Bearer secret for that lookup; must equal community-admin's `CA_CONFIG_SECRET`. If unset, `share_poll` fails closed (denies).
+- `AVAILS_SERVICE_SECRET` — Bearer secret that authorizes **inbound** `schedule_call` from community-admin's call-proposal trigger (#149). Note the direction: `CA_CONFIG_SECRET` is what avails sends *to* CA, this is what CA sends *to* avails. Deliberately a **separate** value — scenius-digest also holds `CA_CONFIG_SECRET`, so reusing it would let scenius-digest book calls and email people. If unset, the service path is simply unavailable and only a list's owner can call `schedule_call`; it never opens the tool up.
 
 ## Task Tracking
 

--- a/server/src/mcp/handler.js
+++ b/server/src/mcp/handler.js
@@ -1,4 +1,5 @@
 // server/src/mcp/handler.js
+import crypto from 'node:crypto';
 import { verifyToken } from './jwt.js';
 import { getClient } from './clients.js';
 import { getClient as getOAuthClient } from '../routes/auth.js';
@@ -15,11 +16,31 @@ function getJwtSecret() {
  * Extract MCP auth context from Bearer JWT token.
  * Returns null if no auth or invalid.
  */
+// Constant-time compare so the shared secret cannot be recovered a byte at a
+// time. Comparing lengths first leaks only the length, which is not a secret.
+function secretMatches(token, secret) {
+  const a = Buffer.from(token);
+  const b = Buffer.from(secret);
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
 async function extractAuthContext(req) {
   const authHeader = req.headers.authorization;
   if (!authHeader?.startsWith('Bearer ')) return null;
 
   const token = authHeader.slice(7);
+
+  // The shared service credential is a caller, not a person. community-admin's
+  // call-proposal trigger acts on behalf of a community, so it has no DID and no
+  // OAuth session — and every tool that needs one must still refuse it, which is
+  // why this returns an explicitly DID-less context rather than a privileged
+  // one. It is checked before the JWT path because it is not a JWT and would
+  // only ever fail verification there.
+  const serviceSecret = process.env.AVAILS_SERVICE_SECRET;
+  if (serviceSecret && secretMatches(token, serviceSecret)) {
+    return { service: 'community-admin', did: null, handle: null, oauthSession: null };
+  }
+
   try {
     const claims = verifyToken(getJwtSecret(), token);
     // mcp_client_id IS the client_id in the new RFC 7591 flow

--- a/server/src/mcp/tools.js
+++ b/server/src/mcp/tools.js
@@ -1026,7 +1026,33 @@ function parseAtUri(uri) {
 // schedule_call (#103, Task 8, Phase 1): books a call straight from a
 // group's standing availability — no poll. Reading availability records is
 // public (no auth), so this tool does not require authContext.
-async function scheduleCall({ scope, durationMinutes, window, title, voterDids }) {
+// This tool books real calls and sends ICS invites to the people it books, so
+// it must never be callable anonymously (#149). Two callers are legitimate:
+//
+//   - a service, via AVAILS_SERVICE_SECRET — community-admin's call-proposal
+//     trigger acts for a community rather than a person, so there is no user
+//     DID to check;
+//   - the owner of the list itself.
+//
+// Ownership is structural rather than looked up: an at:// URI names the repo it
+// lives in, so the DID in the list URI IS its owner. Same shape delete_poll
+// uses, and it cannot drift out of sync with the record it authorizes.
+//
+// Anonymous callers get AUTH_REQUIRED, which the handler turns into a 401
+// pointing at the OAuth metadata — signing in genuinely is the fix for them.
+// A signed-in non-owner gets a plain error instead: another OAuth round trip
+// would not help, and sending them back through one would be a lie.
+function assertMayScheduleFor(listUri, authContext) {
+  if (!authContext) throw new Error('AUTH_REQUIRED');
+  if (authContext.service) return;
+  const owner = String(listUri).slice('at://'.length).split('/')[0];
+  if (authContext.did && authContext.did === owner) return;
+  throw new Error(
+    'Not your list. schedule_call books a call and emails the people it books, so it is limited to the list owner or an authorized service.'
+  );
+}
+
+async function scheduleCall({ scope, durationMinutes, window, title, voterDids }, authContext) {
   const normalizedScope = normalizeScope(scope);
 
   if (normalizedScope.type === 'ca-community') {
@@ -1037,6 +1063,10 @@ async function scheduleCall({ scope, durationMinutes, window, title, voterDids }
   if (normalizedScope.type !== 'atproto-list') {
     throw new Error(`Unsupported scope type "${normalizedScope.type}". Phase 1 only supports "atproto-list".`);
   }
+
+  // After the scope is known to be a list (so there is an owner to compare
+  // against) and before anything reads records or sends mail.
+  assertMayScheduleFor(normalizedScope.value, authContext);
   if (!Number.isInteger(durationMinutes) || durationMinutes <= 0) {
     throw new Error('durationMinutes must be a positive integer');
   }
@@ -1222,7 +1252,7 @@ export async function callTool(name, args, authContext) {
     case 'list_communities':
       return listCommunities();
     case 'schedule_call':
-      return scheduleCall(args);
+      return scheduleCall(args, authContext);
     default:
       throw new Error(`Unknown tool: ${name}`);
   }

--- a/server/test/scheduleCall.test.js
+++ b/server/test/scheduleCall.test.js
@@ -15,6 +15,13 @@ import assert from 'node:assert/strict';
 
 const LIST_URI = 'at://did:plc:creator/app.bsky.graph.list/thelist';
 
+// schedule_call is gated (#149) — it books calls and emails the people it books.
+// These orchestration tests are not about the gate, so they run as the service
+// caller (community-admin's trigger). The gate itself is exercised below.
+const SERVICE = { service: 'community-admin', did: null, handle: null, oauthSession: null };
+const OWNER = { service: null, did: 'did:plc:creator', handle: 'creator.test', oauthSession: null };
+const STRANGER = { service: null, did: 'did:plc:someoneelse', handle: 'nosy.test', oauthSession: null };
+
 function member(did, trust, { timezone = 'UTC' } = {}) {
   return {
     did,
@@ -115,7 +122,7 @@ describe('schedule_call', () => {
       durationMinutes: 60,
       window: WINDOW,
       title: 'Weekly sync',
-    }, null);
+    }, SERVICE);
     const result = JSON.parse(raw);
 
     assert.equal(result.booked, true);
@@ -144,7 +151,7 @@ describe('schedule_call', () => {
       durationMinutes: 60,
       window: WINDOW,
       title: 'Weekly sync',
-    }, null);
+    }, SERVICE);
     const result = JSON.parse(raw);
 
     assert.equal(result.booked, false);
@@ -166,7 +173,7 @@ describe('schedule_call', () => {
       durationMinutes: 60,
       window: WINDOW,
       title: 'Weekly sync',
-    }, null);
+    }, SERVICE);
     const result = JSON.parse(raw);
 
     assert.equal(result.booked, false);
@@ -190,7 +197,7 @@ describe('schedule_call', () => {
       durationMinutes: 30,
       window: WINDOW,
       title: 'Planning call',
-    }, null);
+    }, SERVICE);
     const result = JSON.parse(raw);
 
     assert.equal(result.booked, true);
@@ -214,7 +221,7 @@ describe('schedule_call', () => {
         durationMinutes: 60,
         window: WINDOW,
         title: 'Weekly sync',
-      }, null),
+      }, SERVICE),
       /scope\.type is required/
     );
     assert.deepEqual(fetchCalls, []);
@@ -228,7 +235,7 @@ describe('schedule_call', () => {
         durationMinutes: 60,
         window: WINDOW,
         title: 'Weekly sync',
-      }, null),
+      }, SERVICE),
       /Unknown scope\.type "atproto-lst"/
     );
     assert.deepEqual(fetchCalls, []);
@@ -251,7 +258,7 @@ describe('schedule_call', () => {
       durationMinutes: 60,
       window: WINDOW,
       title: 'Weekly sync',
-    }, null));
+    }, SERVICE));
 
     assert.equal(result.booked, true);
   });
@@ -266,7 +273,7 @@ describe('schedule_call', () => {
         durationMinutes: 60,
         window: WINDOW,
         title: 'Weekly sync',
-      }, null),
+      }, SERVICE),
       /Phase 1/
     );
     assert.deepEqual(fetchCalls, []);
@@ -289,7 +296,7 @@ describe('schedule_call', () => {
       scope: { type: 'atproto-list', value: LIST_URI },
       durationMinutes: 60, window: WINDOW, title: 'Voted call',
       voterDids: ['did:plc:alice', 'did:plc:bob'],
-    }, null));
+    }, SERVICE));
 
     assert.equal(result.booked, true);
     assert.equal(listCalled, false, 'whole-list resolution must NOT run when voterDids is given');
@@ -305,7 +312,7 @@ describe('schedule_call', () => {
       scope: { type: 'atproto-list', value: LIST_URI },
       durationMinutes: 60, window: WINDOW, title: 'Voted call',
       voterDids: ['did:plc:alice', 'did:plc:ghost'],
-    }, null));
+    }, SERVICE));
     assert.equal(result.booked, false);
     assert.equal(result.fallback, 'create_poll');
   });
@@ -316,7 +323,7 @@ describe('schedule_call', () => {
       () => callTool('schedule_call', {
         scope: { type: 'atproto-list', value: LIST_URI },
         durationMinutes: 60, window: WINDOW, title: 'x', voterDids: [],
-      }, null),
+      }, SERVICE),
       /voterDids.*non-empty|non-empty.*voterDids/i
     );
     assert.deepEqual(fetchCalls, []);
@@ -328,15 +335,80 @@ describe('schedule_call', () => {
       () => callTool('schedule_call', {
         scope: { type: 'atproto-list', value: LIST_URI },
         durationMinutes: 60, window: WINDOW, title: 'x', voterDids: 'did:plc:alice',
-      }, null),
+      }, SERVICE),
       /voterDids must be an array/i
     );
     await assert.rejects(
       () => callTool('schedule_call', {
         scope: { type: 'atproto-list', value: LIST_URI },
         durationMinutes: 60, window: WINDOW, title: 'x', voterDids: ['not-a-did'],
-      }, null),
+      }, SERVICE),
       /voterDids must be an array/i
     );
+  });
+});
+
+// #149: the tool books real calls and mails ICS invites to the people it books,
+// and Bluesky lists are public records, so the list URI was never the barrier.
+// It used to accept any caller, including one with no credential at all.
+describe('schedule_call authorization', () => {
+  const ARGS = {
+    scope: { type: 'atproto-list', value: LIST_URI },
+    durationMinutes: 60,
+    window: WINDOW,
+    title: 'Weekly sync',
+  };
+
+  // Every rejection below also asserts nothing was resolved and no mail was
+  // sent. A gate that refuses AFTER doing the work would still leak the
+  // group's schedule and still email people.
+  function assertDidNothing() {
+    assert.deepEqual(fetchCalls, []);
+    assert.deepEqual(sendEmailCalls, []);
+  }
+
+  it('refuses an anonymous caller with AUTH_REQUIRED, which the handler turns into a 401', async () => {
+    resetHooks();
+    resolveListAvailabilityImpl = async () => { throw new Error('must not resolve for an anonymous caller'); };
+    await assert.rejects(() => callTool('schedule_call', ARGS, null), /AUTH_REQUIRED/);
+    assertDidNothing();
+  });
+
+  it('refuses a signed-in stranger, and does NOT send them back through OAuth', async () => {
+    resetHooks();
+    resolveListAvailabilityImpl = async () => { throw new Error('must not resolve for a non-owner'); };
+    // Not AUTH_REQUIRED: they are already authenticated, so another OAuth round
+    // trip would not help and pretending otherwise would be a lie.
+    await assert.rejects(() => callTool('schedule_call', ARGS, STRANGER), /Not your list/);
+    await assert.doesNotReject(async () => {
+      try { await callTool('schedule_call', ARGS, STRANGER); } catch (err) {
+        assert.ok(!/AUTH_REQUIRED/.test(err.message));
+      }
+    });
+    assertDidNothing();
+  });
+
+  it('allows the list owner — the DID in the list URI is its owner, no lookup needed', async () => {
+    resetHooks();
+    resolveListAvailabilityImpl = async () => [member('did:plc:alice', 'auto'), member('did:plc:bob', 'auto')];
+    bestCallSlotsImpl = () => [{ slot: '2026-07-21T14:00', participants: ['did:plc:alice', 'did:plc:bob'], count: 2 }];
+    const result = JSON.parse(await callTool('schedule_call', ARGS, OWNER));
+    assert.equal(result.booked, true);
+  });
+
+  it('allows the service credential, which has no DID at all', async () => {
+    resetHooks();
+    resolveListAvailabilityImpl = async () => [member('did:plc:alice', 'auto'), member('did:plc:bob', 'auto')];
+    bestCallSlotsImpl = () => [{ slot: '2026-07-21T14:00', participants: ['did:plc:alice', 'did:plc:bob'], count: 2 }];
+    const result = JSON.parse(await callTool('schedule_call', ARGS, SERVICE));
+    assert.equal(result.booked, true);
+  });
+
+  it('a DID that merely prefixes the owner is not the owner', async () => {
+    resetHooks();
+    resolveListAvailabilityImpl = async () => { throw new Error('must not resolve'); };
+    const almost = { service: null, did: 'did:plc:creato', handle: 'x', oauthSession: null };
+    await assert.rejects(() => callTool('schedule_call', ARGS, almost), /Not your list/);
+    assertDidNothing();
   });
 });


### PR DESCRIPTION
Closes #149.

`schedule_call` books real calls and mails ICS invites to the people it books, and it accepted **any caller, including one with no credential at all**. The MCP's auth is per-tool and opt-in — the handler returns a null context when there is no Bearer token and treats that as fine — and this tool never opted in. Bluesky lists are public records, so the list URI was never the barrier either.

## Who can call it now

**A service, via `AVAILS_SERVICE_SECRET`.** community-admin's call-proposal trigger acts for a community rather than a person, so there is no user DID to check. `extractAuthContext` recognises the secret *before* the JWT path (it is not a JWT and would only ever fail verification there) and returns an explicitly **DID-less** context, so every tool that needs a real user still refuses it. Compared with `timingSafeEqual`.

**The owner of the list.** Ownership is structural rather than looked up: an `at://` URI names the repo it lives in, so the DID in the list URI *is* its owner. Same shape `delete_poll` uses, and it cannot drift out of sync with the thing it authorizes.

Anonymous callers get `AUTH_REQUIRED`, which the handler turns into a 401 pointing at the OAuth metadata — signing in genuinely is their fix. A signed-in non-owner gets a plain error instead: another OAuth round trip would not help them, and sending them through one would be a lie.

## Why a new secret

Deliberately **not** `CA_CONFIG_SECRET`, which avails already holds and which would have needed no provisioning at all. **scenius-digest holds that same value**, so gating on it would have handed scenius-digest the ability to book calls and mail people — a third holder that already exists, so the privilege creep is real rather than theoretical.

Note the two point in opposite directions: `CA_CONFIG_SECRET` is what avails sends **to** community-admin; `AVAILS_SERVICE_SECRET` is what community-admin sends **to** avails.

## Deploy ordering

Shipped second on purpose. community-admin started sending the header in Citizen-Infra/community-admin@8317972, **deployed and verified SUCCESS before this was opened**, so there is no window in which the trigger is refused.

The reverse order would have left CA booking against a door that had just been locked — and `fire()` swallows the error, leaves `outcome` NULL and retries forever, so nothing would have alerted anyone. The variable is already set on both Railway services.

## Tests

Five new cases, and **every rejection also asserts that nothing was resolved and no mail was sent** — a gate that refuses *after* doing the work would still leak the group's schedule and still email people. Includes a near-miss DID (`did:plc:creato` vs `did:plc:creator`) so a prefix match can never pass for ownership.

The existing orchestration tests all passed `null` as the auth context, which is precisely the hole; they now run as the service caller. Full suite: **184 passed, 0 failed.**

## Follow-up

`add_to_call` (#120) is the same class of operation — it schedules a person and mails them an invite — and must be gated the same way when it is built.
