### PR TITLE
Admin key moves to a header and gets its own secret (#156)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ Railway (single service, Nixpacks builder). Custom domain: avails.zhgnv.com.
 - `OPENMEET_TENANT_ID` — OpenMeet instance tenant (default: `lsdfaopkljdfs`)
 - `CA_MEMBERSHIP_URL` — community-admin base URL; `share_poll` gates on membership via `GET /api/memberships` (S4). A trailing slash is stripped in code.
 - `CA_CONFIG_SECRET` — Bearer secret for that lookup; must equal community-admin's `CA_CONFIG_SECRET`. If unset, `share_poll` fails closed (denies).
+- `AVAILS_ADMIN_SECRET` — Bearer credential for `POST /api/admin/clear-sessions`, which logs every user out. Sent as `Authorization: Bearer <value>`, **never** a query parameter: it was previously `SESSION_SECRET` read from `?key=`, which put a secret into access logs, proxy logs, browser history and `Referer` headers, and that same value signed every MCP access token (#156). **Unset = the endpoint denies everything**; it never falls back to another secret. `SESSION_SECRET` and `MCP_JWT_SECRET` must all three be distinct values.
 - `AVAILS_SERVICE_SECRET` — Bearer secret that authorizes **inbound** `schedule_call` from community-admin's call-proposal trigger (#149). Note the direction: `CA_CONFIG_SECRET` is what avails sends *to* CA, this is what CA sends *to* avails. Deliberately a **separate** value — scenius-digest also holds `CA_CONFIG_SECRET`, so reusing it would let scenius-digest book calls and email people. If unset, the service path is simply unavailable and only a list's owner can call `schedule_call`; it never opens the tool up.
 
 ## Task Tracking

--- a/server/.env.example
+++ b/server/.env.example
@@ -8,4 +8,10 @@ CORS_ORIGINS=
 ATPROTO_CLIENT_ID=https://avails.zhgnv.com/api/auth/client-metadata-v4.json
 ATPROTO_REDIRECT_URI=https://avails.zhgnv.com/api/auth/callback
 SESSION_SECRET=change-me-to-random-string
+
+# Credential for POST /api/admin/clear-sessions, sent as `Authorization: Bearer <value>`.
+# Its own value on purpose: this used to be SESSION_SECRET read from `?key=`, which put
+# a secret into access logs and browser history AND was the MCP token signing key (#156).
+# Unset means the endpoint denies every request — it never falls back to another secret.
+AVAILS_ADMIN_SECRET=change-me-to-a-different-random-string
 RESEND_API_KEY=re_xxxxxxxxxxxx

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -19,6 +19,7 @@ import { spaFallback } from './middleware/spaFallback.js';
 import mcpOauthRoutes from './mcp/oauth.js';
 import { handleMcp, handleMcpDelete } from './mcp/handler.js';
 import { pollOgHandler } from './lib/og.js';
+import { secretMatches, bearerFrom } from './lib/bearerAuth.js';
 
 dotenv.config();
 
@@ -129,9 +130,18 @@ app.use('/mcp', mcpOauthRoutes);
 app.post('/mcp', mcpLimiter, handleMcp);
 app.delete('/mcp', handleMcpDelete);
 
-// Admin: clear all sessions (requires SESSION_SECRET as query param)
+// Admin: clear all sessions. Logs every user out, so it is credentialed.
+//
+// The credential arrives in an Authorization header and has its own variable.
+// It used to be SESSION_SECRET read from `?key=`, which was two problems at
+// once (#156): a secret in a URL is recorded by access logs, proxies, browser
+// history and Referer headers, and that same value was the HS256 signing key
+// for every MCP access token.
+//
+// Fails closed when AVAILS_ADMIN_SECRET is unset — an admin endpoint with no
+// credential configured must deny, never fall back to another secret.
 app.post('/api/admin/clear-sessions', async (req, res) => {
-  if (req.query.key !== process.env.SESSION_SECRET) {
+  if (!secretMatches(bearerFrom(req), process.env.AVAILS_ADMIN_SECRET)) {
     return res.status(403).json({ error: 'Invalid key' });
   }
   const appCount = sessions.size;

--- a/server/src/lib/bearerAuth.js
+++ b/server/src/lib/bearerAuth.js
@@ -1,0 +1,41 @@
+import crypto from 'node:crypto';
+
+/**
+ * Constant-time secret comparison, so a value cannot be recovered a byte at a
+ * time from response timing. Comparing lengths first leaks only the length,
+ * which is not itself a secret.
+ *
+ * Fails closed on anything that is not a non-empty string, which is what makes
+ * an unset environment variable deny rather than match. `'' === ''` would
+ * otherwise let a caller sending nothing authenticate against an unconfigured
+ * secret — the exact shape of an accidental open door.
+ *
+ * @param {unknown} token  the credential presented by the caller
+ * @param {unknown} secret the configured credential
+ * @returns {boolean}
+ */
+export function secretMatches(token, secret) {
+  if (typeof token !== 'string' || typeof secret !== 'string') return false;
+  if (token.length === 0 || secret.length === 0) return false;
+  const a = Buffer.from(token);
+  const b = Buffer.from(secret);
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+/**
+ * The Bearer credential from an Authorization header, or null.
+ *
+ * Deliberately does NOT read query parameters. A credential in a URL is
+ * recorded by server access logs, upstream proxies and CDNs, browser history,
+ * and Referer headers on any outbound link — and stays in the shell history of
+ * whoever ran the command (#156).
+ *
+ * @param {{headers?: Record<string, unknown>}} req
+ * @returns {string|null}
+ */
+export function bearerFrom(req) {
+  const header = req?.headers?.authorization;
+  if (typeof header !== 'string' || !header.startsWith('Bearer ')) return null;
+  const token = header.slice('Bearer '.length).trim();
+  return token || null;
+}

--- a/server/src/mcp/handler.js
+++ b/server/src/mcp/handler.js
@@ -1,6 +1,6 @@
 // server/src/mcp/handler.js
-import crypto from 'node:crypto';
 import { verifyToken } from './jwt.js';
+import { secretMatches } from '../lib/bearerAuth.js';
 import { getClient } from './clients.js';
 import { getClient as getOAuthClient } from '../routes/auth.js';
 import { callTool, listTools } from './tools.js';
@@ -16,14 +16,6 @@ function getJwtSecret() {
  * Extract MCP auth context from Bearer JWT token.
  * Returns null if no auth or invalid.
  */
-// Constant-time compare so the shared secret cannot be recovered a byte at a
-// time. Comparing lengths first leaks only the length, which is not a secret.
-function secretMatches(token, secret) {
-  const a = Buffer.from(token);
-  const b = Buffer.from(secret);
-  return a.length === b.length && crypto.timingSafeEqual(a, b);
-}
-
 async function extractAuthContext(req) {
   const authHeader = req.headers.authorization;
   if (!authHeader?.startsWith('Bearer ')) return null;

--- a/server/test/bearerAuth.test.js
+++ b/server/test/bearerAuth.test.js
@@ -1,0 +1,82 @@
+/**
+ * Shared bearer-credential helpers (#156). These back both the MCP service
+ * credential (#149) and the clear-sessions admin route, so the failure modes
+ * below are the ones that would open either door.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { secretMatches, bearerFrom } from '../src/lib/bearerAuth.js';
+
+describe('secretMatches', () => {
+  it('accepts only an exact match', () => {
+    assert.equal(secretMatches('s3cret', 's3cret'), true);
+    assert.equal(secretMatches('s3cret', 's3crey'), false);
+    assert.equal(secretMatches('s3cret', 's3cre'), false);   // shorter
+    assert.equal(secretMatches('s3cret', 's3crett'), false); // longer
+  });
+
+  it('a prefix of the secret is not the secret', () => {
+    // The length check runs first, so this can never reach timingSafeEqual —
+    // but it is the mistake a naive startsWith would make, so pin it.
+    assert.equal(secretMatches('s3c', 's3cret'), false);
+    assert.equal(secretMatches('s3cretXX', 's3cret'), false);
+  });
+
+  it('fails closed when the secret is unset or empty', () => {
+    // The one that matters: an unconfigured AVAILS_ADMIN_SECRET is undefined,
+    // and a caller sending nothing presents ''. Naive equality would make those
+    // two match each other and leave the endpoint wide open.
+    assert.equal(secretMatches('', ''), false);
+    assert.equal(secretMatches('', undefined), false);
+    assert.equal(secretMatches(undefined, undefined), false);
+    assert.equal(secretMatches(null, null), false);
+    assert.equal(secretMatches('anything', undefined), false);
+    assert.equal(secretMatches('anything', ''), false);
+  });
+
+  it('fails closed on non-string input rather than throwing', () => {
+    // Buffer.from(42) throws, and an exception inside an auth check is a
+    // 500 at best and a bypass at worst depending on where it is caught.
+    for (const bad of [42, {}, [], true, Symbol('x')]) {
+      assert.equal(secretMatches(bad, 'secret'), false);
+      assert.equal(secretMatches('secret', bad), false);
+    }
+  });
+
+  it('handles multi-byte secrets without throwing on unequal byte lengths', () => {
+    // 'é' is one character but two UTF-8 bytes: comparing by string length
+    // then by Buffer would hand timingSafeEqual two different-sized buffers,
+    // which throws. Guard is on the Buffer lengths, so this is safe.
+    assert.equal(secretMatches('é', 'ee'), false);
+    assert.equal(secretMatches('é', 'é'), true);
+  });
+});
+
+describe('bearerFrom', () => {
+  const req = (authorization) => ({ headers: authorization === undefined ? {} : { authorization } });
+
+  it('extracts a Bearer token', () => {
+    assert.equal(bearerFrom(req('Bearer abc123')), 'abc123');
+    assert.equal(bearerFrom(req('Bearer   abc123  ')), 'abc123');
+  });
+
+  it('returns null for anything that is not a Bearer header', () => {
+    assert.equal(bearerFrom(req(undefined)), null);
+    assert.equal(bearerFrom(req('')), null);
+    assert.equal(bearerFrom(req('Basic abc123')), null);
+    assert.equal(bearerFrom(req('bearer abc123')), null); // case-sensitive scheme
+    assert.equal(bearerFrom(req('Bearer')), null);
+    assert.equal(bearerFrom(req('Bearer    ')), null);    // whitespace only
+    assert.equal(bearerFrom({}), null);
+    assert.equal(bearerFrom(undefined), null);
+  });
+
+  it('never reads a credential from the query string', () => {
+    // The whole point of #156: `?key=<secret>` is recorded by access logs,
+    // proxies, browser history and Referer headers. Passing one must not
+    // authenticate, no matter how it is spelled.
+    assert.equal(bearerFrom({ headers: {}, query: { key: 'the-secret' } }), null);
+    assert.equal(bearerFrom({ query: { access_token: 'the-secret' } }), null);
+  });
+});


### PR DESCRIPTION
Fix 2 of #156. (Fix 1, rotating `MCP_JWT_SECRET` off `SESSION_SECRET`, was an environment change and is already live.)

## The problem

`POST /api/admin/clear-sessions` took its credential as `?key=`, compared it with `!==`, and compared it against `SESSION_SECRET` — which, with `MCP_JWT_SECRET` unset in production, was *also* the HS256 signing key for every MCP access token.

A secret in a query string is not private. It is written to server access logs, upstream proxy and CDN logs, browser history and `Referer` headers, and it stays in the shell history of whoever ran the command. So the key that minted MCP tokens was being deposited in half a dozen places by design.

## What changes

The endpoint now takes its own `AVAILS_ADMIN_SECRET`, reads it from an `Authorization: Bearer` header, and compares with `timingSafeEqual`.

**It fails closed when the variable is unset.** An admin endpoint with no credential configured must deny — falling back to another secret is how these two got entangled in the first place.

Comparison and header parsing move into `server/src/lib/bearerAuth.js`, **shared** with the MCP service credential from #149 rather than copied. `handler.js` loses its local copy.

`bearerFrom` reads only the `Authorization` header. A credential passed as a query parameter cannot authenticate no matter how it is spelled — asserted directly in the tests rather than left as an absence.

## Tests

Eight cases over the failure modes that would open either door:

- prefixes and length mismatches in both directions
- **empty and unset secrets** — the one that matters, since an unset variable is `undefined` and a caller sending nothing presents `''`; naive equality would let those two authenticate each other
- non-string input — `Buffer.from(42)` throws, and an exception inside an auth check is a 500 at best and a bypass at worst
- **multi-byte secrets** — `'é'` is one character but two UTF-8 bytes, so `'é'` against `'ee'` would hand `timingSafeEqual` two different-sized buffers and throw if the guard compared string lengths instead of Buffer lengths

Full suite: **192 passed, 0 failed.**

## Deploy note

`AVAILS_ADMIN_SECRET` is **already set** on `avails-web` production (with `--skip-deploys`, so it has been inert). All four secrets — `SESSION_SECRET`, `MCP_JWT_SECRET`, `AVAILS_ADMIN_SECRET`, `AVAILS_SERVICE_SECRET` — are now distinct values, verified. So this merges into an environment that is already correct and the endpoint stays usable rather than failing closed on arrival.

**Breaking for any existing caller** of `clear-sessions` using `?key=`. That is the point; there is deliberately no grace period, since accepting the old form would preserve exactly the leak being fixed.

## Still open on #156

Fix 3: validate `iss` and `aud` in `verifyToken`. It checks signature and expiry only, which matters more now that avails answers on two hosts with one key (#150).
