### PR TITLE
verifyToken now checks iss and aud (#156)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,8 @@ Railway (single service, Nixpacks builder). Custom domain: avails.zhgnv.com.
 - `ATPROTO_REDIRECT_URI` — OAuth callback URL
 - `ATPROTO_PRIVATE_KEY` — base64-encoded ES256 JWK (Railway mangles raw JSON)
 - `SESSION_SECRET` — cookie signing
-- `MCP_JWT_SECRET` — optional, JWT signing for MCP tokens (falls back to SESSION_SECRET)
+- `MCP_JWT_SECRET` — JWT signing for MCP tokens. Falls back to `SESSION_SECRET` if unset, which is why it must be **set** in production: `SESSION_SECRET` was also an admin credential sent in a URL, so the two were entangled (#156). Changing this value invalidates every outstanding MCP token — clients see "token expired" and must re-run OAuth.
+- `MCP_ACCEPTED_ISSUERS` — optional, comma-separated. Extra `iss`/`aud` values accepted on an MCP token alongside the live `CLIENT_URL`. `verifyToken` validates both claims (#156); without this list, changing `CLIENT_URL` — which the `avails.zhgnv.com` → `avails.citizeninfra.org` migration will do (#150) — invalidates every outstanding token at once. Put the old URL here for the duration of the cutover to make it a rollover rather than a flag day. Same shape as community-admin's `CA_ACCEPTED_DIDS`.
 - `AVAILS_SERVICE_IDENTIFIER` — avails' own ATProto account (handle or DID) for the service-repo response store (#42). Setting this + `AVAILS_SERVICE_APP_PASSWORD` **activates** the service path; unset = legacy creator-session writes.
 - `AVAILS_SERVICE_APP_PASSWORD` — app password for that account (not the login password)
 - `AVAILS_SERVICE_PDS` — optional; the account's PDS host for login (default `https://bsky.social`)

--- a/server/src/mcp/handler.js
+++ b/server/src/mcp/handler.js
@@ -1,5 +1,6 @@
 // server/src/mcp/handler.js
 import { verifyToken } from './jwt.js';
+import { acceptedIssuers } from './issuers.js';
 import { secretMatches } from '../lib/bearerAuth.js';
 import { getClient } from './clients.js';
 import { getClient as getOAuthClient } from '../routes/auth.js';
@@ -34,7 +35,13 @@ async function extractAuthContext(req) {
   }
 
   try {
-    const claims = verifyToken(getJwtSecret(), token);
+    // A signature only proves we minted the token; iss/aud prove we minted it
+    // for THIS service. They were written and never read (#156), and avails
+    // answers on two domains with one signing key (#150).
+    const claims = verifyToken(getJwtSecret(), token, {
+      issuer: acceptedIssuers(),
+      audience: acceptedIssuers(),
+    });
     // mcp_client_id IS the client_id in the new RFC 7591 flow
     const clientId = claims.mcp_client_id || claims.client_id;
     const mcpClient = getClient(clientId);

--- a/server/src/mcp/issuers.js
+++ b/server/src/mcp/issuers.js
@@ -1,0 +1,33 @@
+/**
+ * This service's external identity, and the identities it will accept on a
+ * token. Kept in its own module so both the OAuth router and the request
+ * handler can read it without importing each other.
+ */
+
+export function getExternalBase() {
+  return process.env.CLIENT_URL || 'http://localhost:5173';
+}
+
+/**
+ * Issuer/audience values accepted on an MCP token.
+ *
+ * `getExternalBase()` is included verbatim rather than normalised, so it is
+ * byte-identical to what `signToken` writes. A normalising step here that
+ * signToken does not perform would reject our own freshly-minted tokens.
+ *
+ * `MCP_ACCEPTED_ISSUERS` is a comma-separated grace list, and it exists for a
+ * specific upcoming event: CLIENT_URL is `avails.zhgnv.com` today and is due to
+ * become `avails.citizeninfra.org` (#150). Without a grace list that cutover
+ * invalidates every outstanding MCP token at once, presenting to every client
+ * as "token expired" — which is already the third distinct cause wearing that
+ * one message. Listing the old value here during the migration turns a flag day
+ * into a rollover. Same shape as community-admin's CA_ACCEPTED_DIDS
+ * (community-admin#99), which #150 already names as the pattern to copy.
+ */
+export function acceptedIssuers() {
+  const extra = (process.env.MCP_ACCEPTED_ISSUERS || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return [...new Set([getExternalBase(), ...extra])];
+}

--- a/server/src/mcp/jwt.js
+++ b/server/src/mcp/jwt.js
@@ -34,13 +34,38 @@ export function signToken(secret, payload, expiresInSecs = 3600) {
 }
 
 /**
+ * True when a JWT claim matches one of the expected values. Handles the claim
+ * being an array (`aud` is allowed to be one by RFC 7519, even though signToken
+ * only ever writes a string) and rejects anything non-string or empty.
+ */
+function claimMatches(value, expected) {
+  const allowed = Array.isArray(expected) ? expected : [expected];
+  const values = Array.isArray(value) ? value : [value];
+  return values.some((v) => typeof v === 'string' && v.length > 0 && allowed.includes(v));
+}
+
+/**
  * Verify a JWT token with HS256
+ *
+ * A valid signature proves only that WE minted this token — not that we minted
+ * it for THIS service. `iss` and `aud` are written by signToken and were never
+ * read back, so a token issued under one identity was accepted under any other
+ * sharing the signing key. avails answers on two domains today (#150) with one
+ * MCP_JWT_SECRET, so that is a live condition rather than a hypothetical.
+ *
+ * Both checks are opt-in: passing neither preserves the old behaviour, which
+ * keeps this a safe drop-in for any caller that has no expectation to state.
+ *
  * @param {string} secret - The secret key for verification
  * @param {string} token - The JWT token to verify
+ * @param {object} [expect] - Optional claim expectations
+ * @param {string|string[]} [expect.issuer] - Acceptable `iss` values
+ * @param {string|string[]} [expect.audience] - Acceptable `aud` values
  * @returns {object} The decoded claims
- * @throws {Error} If token is invalid, signature doesn't match, or token is expired
+ * @throws {Error} If token is invalid, signature doesn't match, token is expired,
+ *                 or a stated issuer/audience expectation is not met
  */
-export function verifyToken(secret, token) {
+export function verifyToken(secret, token, { issuer, audience } = {}) {
   const parts = token.split('.');
 
   if (parts.length !== 3) {
@@ -73,6 +98,17 @@ export function verifyToken(secret, token) {
   const now = Math.floor(Date.now() / 1000);
   if (payload.exp < now) {
     throw new Error('Token expired');
+  }
+
+  // Distinct messages on purpose. "Token expired" and "wrong issuer" are the
+  // same symptom to a client — it re-runs OAuth — but completely different
+  // causes to whoever reads the log, and today has already shown how easily
+  // those get conflated.
+  if (issuer !== undefined && !claimMatches(payload.iss, issuer)) {
+    throw new Error(`Invalid issuer: ${JSON.stringify(payload.iss ?? null)}`);
+  }
+  if (audience !== undefined && !claimMatches(payload.aud, audience)) {
+    throw new Error(`Invalid audience: ${JSON.stringify(payload.aud ?? null)}`);
   }
 
   return payload;

--- a/server/src/mcp/oauth.js
+++ b/server/src/mcp/oauth.js
@@ -6,6 +6,7 @@ import { getClient as getOAuthClient } from '../routes/auth.js';
 import { createSession } from '../lib/sessionStore.js';
 import { registerClient, getClient, bindClientDid } from './clients.js';
 import { signToken } from './jwt.js';
+import { getExternalBase } from './issuers.js';
 import { saveNow } from '../lib/persistence.js';
 
 const router = Router();
@@ -20,9 +21,6 @@ function getJwtSecret() {
   return process.env.MCP_JWT_SECRET || process.env.SESSION_SECRET;
 }
 
-function getExternalBase() {
-  return process.env.CLIENT_URL || 'http://localhost:5173';
-}
 
 // --- Well-known endpoints ---
 

--- a/server/test/mcpJwt.test.js
+++ b/server/test/mcpJwt.test.js
@@ -1,0 +1,117 @@
+/**
+ * MCP token issuer/audience validation (#156, fix 3).
+ *
+ * signToken has always written `iss` and `aud`; verifyToken never read them
+ * back, so a token minted under one identity was accepted under any other
+ * sharing the signing key. avails answers on two domains today (#150) with one
+ * MCP_JWT_SECRET, which is what makes that a live condition and not a
+ * hypothetical.
+ */
+
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { signToken, verifyToken } from '../src/mcp/jwt.js';
+import { acceptedIssuers, getExternalBase } from '../src/mcp/issuers.js';
+
+const SECRET = 'test-signing-secret';
+const HOME = 'https://avails.example';
+const OTHER = 'https://someone-else.example';
+
+const mint = (claims, secret = SECRET) => signToken(secret, claims, 3600);
+
+describe('verifyToken issuer/audience', () => {
+  it('accepts a token whose iss and aud match', () => {
+    const t = mint({ sub: 'did:plc:a', iss: HOME, aud: HOME });
+    const claims = verifyToken(SECRET, t, { issuer: HOME, audience: HOME });
+    assert.equal(claims.sub, 'did:plc:a');
+  });
+
+  it('rejects a token minted for a different issuer', () => {
+    // The bug: same signing key, different identity. Before this check the
+    // token below verified cleanly.
+    const t = mint({ sub: 'did:plc:a', iss: OTHER, aud: OTHER });
+    assert.throws(() => verifyToken(SECRET, t, { issuer: HOME }), /Invalid issuer/);
+    assert.throws(() => verifyToken(SECRET, t, { audience: HOME }), /Invalid audience/);
+  });
+
+  it('rejects a token with the claim missing entirely', () => {
+    const t = mint({ sub: 'did:plc:a' });
+    assert.throws(() => verifyToken(SECRET, t, { issuer: HOME }), /Invalid issuer/);
+    assert.throws(() => verifyToken(SECRET, t, { audience: HOME }), /Invalid audience/);
+  });
+
+  it('accepts any value in a list — the grace list a domain migration needs', () => {
+    const old = mint({ sub: 'did:plc:a', iss: OTHER, aud: OTHER });
+    const now = mint({ sub: 'did:plc:a', iss: HOME, aud: HOME });
+    const both = { issuer: [HOME, OTHER], audience: [HOME, OTHER] };
+    assert.equal(verifyToken(SECRET, old, both).sub, 'did:plc:a');
+    assert.equal(verifyToken(SECRET, now, both).sub, 'did:plc:a');
+  });
+
+  it('handles an array aud, which RFC 7519 permits even though we never mint one', () => {
+    const t = mint({ sub: 'did:plc:a', aud: [OTHER, HOME] });
+    assert.equal(verifyToken(SECRET, t, { audience: HOME }).sub, 'did:plc:a');
+    assert.throws(() => verifyToken(SECRET, t, { audience: 'https://third.example' }), /Invalid audience/);
+  });
+
+  it('rejects non-string and empty claims rather than coercing them', () => {
+    for (const bad of [42, null, '', {}]) {
+      const t = mint({ sub: 'did:plc:a', iss: bad });
+      assert.throws(() => verifyToken(SECRET, t, { issuer: HOME }), /Invalid issuer/);
+    }
+  });
+
+  it('stating no expectation preserves the old behaviour', () => {
+    // Backward compatibility is what makes this a safe drop-in: a caller with
+    // nothing to assert gets exactly what it got before.
+    const t = mint({ sub: 'did:plc:a', iss: OTHER, aud: OTHER });
+    assert.equal(verifyToken(SECRET, t).sub, 'did:plc:a');
+  });
+
+  it('signature and expiry are still checked first', () => {
+    const t = mint({ sub: 'did:plc:a', iss: HOME, aud: HOME });
+    assert.throws(() => verifyToken('wrong-secret', t, { issuer: HOME }), /Invalid signature/);
+
+    const expired = signToken(SECRET, { sub: 'did:plc:a', iss: OTHER, aud: OTHER }, -10);
+    // Wrong issuer AND expired: the expiry message wins, so a routine expiry is
+    // never misreported as an identity problem.
+    assert.throws(() => verifyToken(SECRET, expired, { issuer: HOME }), /Token expired/);
+  });
+});
+
+describe('acceptedIssuers', () => {
+  const saved = { CLIENT_URL: process.env.CLIENT_URL, MCP_ACCEPTED_ISSUERS: process.env.MCP_ACCEPTED_ISSUERS };
+  afterEach(() => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it('is the live identity when no grace list is set', () => {
+    process.env.CLIENT_URL = HOME;
+    delete process.env.MCP_ACCEPTED_ISSUERS;
+    assert.deepEqual(acceptedIssuers(), [HOME]);
+  });
+
+  it('adds the grace list, trimming and dropping empties', () => {
+    process.env.CLIENT_URL = HOME;
+    process.env.MCP_ACCEPTED_ISSUERS = ` ${OTHER} , , https://third.example ,`;
+    assert.deepEqual(acceptedIssuers(), [HOME, OTHER, 'https://third.example']);
+  });
+
+  it('deduplicates when the grace list repeats the live identity', () => {
+    process.env.CLIENT_URL = HOME;
+    process.env.MCP_ACCEPTED_ISSUERS = HOME;
+    assert.deepEqual(acceptedIssuers(), [HOME]);
+  });
+
+  it('always contains exactly what signToken would write, byte for byte', () => {
+    // A trailing slash is the trap: normalising here but not in signToken would
+    // reject our own freshly-minted tokens.
+    process.env.CLIENT_URL = 'https://avails.example/';
+    delete process.env.MCP_ACCEPTED_ISSUERS;
+    const t = mint({ sub: 'did:plc:a', iss: getExternalBase(), aud: getExternalBase() });
+    assert.equal(verifyToken(SECRET, t, { issuer: acceptedIssuers(), audience: acceptedIssuers() }).sub, 'did:plc:a');
+  });
+});


### PR DESCRIPTION
Closes #156. Fix 3 of 3 — fix 1 (rotate `MCP_JWT_SECRET` off `SESSION_SECRET`) and fix 2 (#157, admin key into a header) are already live.

`signToken` has always written `iss` and `aud`. `verifyToken` never read either back, so it proved only that **we** minted a token — never that we minted it for **this** service. Any token signed with the same key was accepted under any identity. avails answers on two domains today with one `MCP_JWT_SECRET` (#150), so that was a live condition rather than a hypothetical.

## The list is the point, not the check

Both checks are opt-in — `verifyToken` with no expectations behaves exactly as before, so it stays a safe drop-in for callers with nothing to assert. Only the MCP handler states expectations.

What matters is that the accepted values are a **list**. `CLIENT_URL` is `avails.zhgnv.com` and is due to become `avails.citizeninfra.org`. Validating against a single value would make that cutover invalidate **every outstanding MCP token simultaneously** — surfacing to every client as *"token expired"*, which today has already been established as one message with three distinct causes:

1. a DID binding lost to a restart before the persistence flush (#153)
2. a rotated signing key (#156 fix 1)
3. and, without this list, a changed issuer

`MCP_ACCEPTED_ISSUERS` keeps the old URL valid across the migration, turning a flag day into a rollover. Same shape as community-admin's `CA_ACCEPTED_DIDS`, which #150 already names as the pattern to copy. So this ships the mechanism #150 will need, before #150 needs it.

## Details worth flagging

**The live identity goes into the accepted list verbatim, not normalised.** A trailing slash is the trap: stripping one here that `signToken` does not strip would reject our own freshly-minted tokens. There's a test pinning exactly that, because it's invisible until someone writes `CLIENT_URL` with a slash.

**Expiry is still checked before issuer**, so a routine expiry is never misreported as an identity problem — and the two messages are deliberately distinct for whoever reads the log.

`getExternalBase` and `acceptedIssuers` move to `mcp/issuers.js` so the handler and the OAuth router can both read them without importing each other.

## Impact on live sessions

**None.** Production tokens carry `iss`/`aud` = `CLIENT_URL`, which is exactly what `acceptedIssuers()` returns, so no existing session is invalidated and no re-authorization is needed. I'll confirm that against the real MCP after deploy rather than asserting it.

## Tests

12 new cases: matching and mismatched claims, missing claims, list membership, an array `aud` (RFC 7519 permits one even though we never mint one), non-string and empty claims, the no-expectation backward-compatibility path, ordering against signature and expiry, and the verbatim/trailing-slash case above.

Full suite: **204 passed, 0 failed** — including the DID-binding durability and `schedule_call` authorization suites, both of which run through the code path this changes.
