### PR TITLE
Name avails.citizeninfra.org as the live host (#150)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Open-source group scheduling on the AT Protocol. An alternative to [LettuceMeet](https://lettucemeet.com/) where your polls live in your Bluesky account — not a centralized database.
 
-**Live at [avails.zhgnv.com](https://avails.zhgnv.com)**
+**Live at [avails.citizeninfra.org](https://avails.citizeninfra.org)**
+
+<sub>`avails.zhgnv.com` also serves the same app and will keep working. The move to CIBC's own domain is in progress — see [#150](https://github.com/Citizen-Infra/avails/issues/150).</sub>
 
 <!-- TODO: Add screenshot of the heatmap grid with multiple responses -->
 

--- a/client/index.html
+++ b/client/index.html
@@ -8,7 +8,7 @@
     <meta property="og:title" content="Avails — Group Scheduling" />
     <meta property="og:description" content="Open-source group scheduling on the AT Protocol. Your polls live in your Bluesky account." />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://avails.zhgnv.com" />
+    <meta property="og:url" content="https://avails.citizeninfra.org" />
     <meta name="theme-color" content="#0d9488" />
     <link rel="icon" type="image/png" href="/icon-512.png" />
     <script src="https://accounts.google.com/gsi/client" async defer></script>

--- a/client/src/pages/Terms.jsx
+++ b/client/src/pages/Terms.jsx
@@ -21,7 +21,7 @@ export default function Terms() {
         <div className="space-y-6 text-base text-[#1a1a1a] leading-relaxed">
           <section className="space-y-3">
             <h2 className="text-xl font-semibold">What this is</h2>
-            <p>Avails is a free, open-source scheduling tool operated by <a href="https://github.com/Citizen-Infra" className="text-[#0d9488] underline underline-offset-2" target="_blank" rel="noopener noreferrer">Citizen Infrastructure</a>. These terms cover your use of avails.zhgnv.com.</p>
+            <p>Avails is a free, open-source scheduling tool operated by <a href="https://github.com/Citizen-Infra" className="text-[#0d9488] underline underline-offset-2" target="_blank" rel="noopener noreferrer">Citizen Infrastructure</a>. These terms cover your use of avails.citizeninfra.org, and of avails.zhgnv.com, which serves the same service.</p>
           </section>
 
           <section className="space-y-3">


### PR DESCRIPTION
Part of #150. Step 2 of its sequence — the zero-risk half, so new readers and new work stop inheriting the personal domain. **No behaviour changes, no env changes, no OAuth changes.**

Three strings:

| File | Change |
|---|---|
| `README.md` | "Live at" → `avails.citizeninfra.org`, with a note that the old host still serves |
| `client/index.html` | `og:url` → the new host |
| `client/src/pages/Terms.jsx` | named one host in a document that covers both; now names both |

## What is deliberately NOT in here

#150 groups `.env.example` into the zero-risk step. Three things that look like they belong are held back, because each is coupled to the OAuth migration that issue keeps for last:

**`server/.env.example` — `ATPROTO_CLIENT_ID` / `ATPROTO_REDIRECT_URI`.** These two are the host-bound OAuth pair that step 4 exists to move. Pointing the example at a host production does not use yet would mislead whoever configures from it.

**`server/src/routes/responses.js:20`** tells a signed-out creator to sign back in at `avails.zhgnv.com`. That is currently **correct** and must not be updated early. `ATPROTO_REDIRECT_URI` still serves the callback from the old host, and `auth.js:203` writes the session cookie with `res.cookie(...)` and **no `domain`**, making it host-only. Directing someone to the new host to sign in would complete the OAuth round trip successfully, write the cookie on the old host, and drop them on the new one signed out — no error, nothing logged.

**`client/src/pages/About.jsx`'s `claude mcp add` line.** MCP OAuth discovery is host-bound and `getExternalBase()` is `CLIENT_URL`, so a client added against the new host would be told its authorization server is the old one. It works today because both hosts serve, but it crosses hosts mid-flow and belongs with the `CLIENT_URL` move.

That cookie behaviour is the fourth identity anchor on `CLIENT_URL`, alongside the ICS UID, the MCP OAuth issuer, and email/redirect links — see the thread on #150.

## Gate

`cd client && npm run build` clean, which is the only client-side gate. No server files touched.
