### PR TITLE
Move the last host strings now the OAuth cutover is done (#150)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Always use `frontend-design` skill for visual/UI tasks. Always query shadcn MCP 
 
 ## Deployment
 
-Railway (single service, Nixpacks builder). Custom domain: avails.zhgnv.com.
+Railway (single service, Nixpacks builder). Custom domain: **avails.citizeninfra.org** (since 2026-08-04, #150). `avails.zhgnv.com` is still a Railway domain on the same service but no longer serves — `LEGACY_HOSTS` makes it 308 to the live host.
 - `railway.json` configures build command, start command, and `watchPatterns` (only code changes trigger deploys)
 - `.node-version` = 22 (required for Vite 7 + Tailwind v4)
 - Railway volume mounted at `/data` for session persistence

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Open-source group scheduling on the AT Protocol. An alternative to [LettuceMeet]
 
 **Live at [avails.citizeninfra.org](https://avails.citizeninfra.org)**
 
-<sub>`avails.zhgnv.com` also serves the same app and will keep working. The move to CIBC's own domain is in progress — see [#150](https://github.com/Citizen-Infra/avails/issues/150).</sub>
+<sub>`avails.zhgnv.com` permanently redirects here as of 2026-08-04 ([#150](https://github.com/Citizen-Infra/avails/issues/150)). Old links keep working; sign-in and the MCP endpoint live on the new host only.</sub>
 
 <!-- TODO: Add screenshot of the heatmap grid with multiple responses -->
 

--- a/client/src/pages/About.jsx
+++ b/client/src/pages/About.jsx
@@ -148,7 +148,7 @@ export default function About() {
           </p>
 
           <div className="mt-10 rounded-xl bg-[#f5f3f0] p-8">
-            <p className="text-sm font-mono text-[#6b6560] mb-4">$ claude mcp add -s local -t http avails https://avails.zhgnv.com/mcp</p>
+            <p className="text-sm font-mono text-[#6b6560] mb-4">$ claude mcp add -s local -t http avails https://avails.citizeninfra.org/mcp</p>
             <div className="grid sm:grid-cols-2 gap-6 mt-6">
               <div>
                 <p className="text-sm font-semibold text-[#0d9488] uppercase tracking-wider mb-2">

--- a/client/src/pages/Terms.jsx
+++ b/client/src/pages/Terms.jsx
@@ -21,7 +21,7 @@ export default function Terms() {
         <div className="space-y-6 text-base text-[#1a1a1a] leading-relaxed">
           <section className="space-y-3">
             <h2 className="text-xl font-semibold">What this is</h2>
-            <p>Avails is a free, open-source scheduling tool operated by <a href="https://github.com/Citizen-Infra" className="text-[#0d9488] underline underline-offset-2" target="_blank" rel="noopener noreferrer">Citizen Infrastructure</a>. These terms cover your use of avails.citizeninfra.org, and of avails.zhgnv.com, which serves the same service.</p>
+            <p>Avails is a free, open-source scheduling tool operated by <a href="https://github.com/Citizen-Infra" className="text-[#0d9488] underline underline-offset-2" target="_blank" rel="noopener noreferrer">Citizen Infrastructure</a>. These terms cover your use of avails.citizeninfra.org. The former address, avails.zhgnv.com, now redirects here.</p>
           </section>
 
           <section className="space-y-3">

--- a/server/.env.example
+++ b/server/.env.example
@@ -5,8 +5,13 @@ CLIENT_URL=http://localhost:5173
 # migration to keep the old host working while CLIENT_URL already points at the
 # new one (#151).
 CORS_ORIGINS=
-ATPROTO_CLIENT_ID=https://avails.zhgnv.com/api/auth/client-metadata-v4.json
-ATPROTO_REDIRECT_URI=https://avails.zhgnv.com/api/auth/callback
+ATPROTO_CLIENT_ID=https://avails.citizeninfra.org/api/auth/client-metadata-v4.json
+ATPROTO_REDIRECT_URI=https://avails.citizeninfra.org/api/auth/callback
+# Both must name the SAME host as CLIENT_URL. The callback writes the session
+# cookie host-only (auth.js, res.cookie with no domain), so a callback on one
+# host and a CLIENT_URL on another lands the user signed out with no error.
+# Retired hosts that should forward here instead, comma-separated (#150).
+LEGACY_HOSTS=
 SESSION_SECRET=change-me-to-random-string
 
 # Credential for POST /api/admin/clear-sessions, sent as `Authorization: Bearer <value>`.

--- a/server/src/mcp/issuers.js
+++ b/server/src/mcp/issuers.js
@@ -15,14 +15,18 @@ export function getExternalBase() {
  * byte-identical to what `signToken` writes. A normalising step here that
  * signToken does not perform would reject our own freshly-minted tokens.
  *
- * `MCP_ACCEPTED_ISSUERS` is a comma-separated grace list, and it exists for a
- * specific upcoming event: CLIENT_URL is `avails.zhgnv.com` today and is due to
- * become `avails.citizeninfra.org` (#150). Without a grace list that cutover
- * invalidates every outstanding MCP token at once, presenting to every client
- * as "token expired" — which is already the third distinct cause wearing that
- * one message. Listing the old value here during the migration turns a flag day
- * into a rollover. Same shape as community-admin's CA_ACCEPTED_DIDS
- * (community-admin#99), which #150 already names as the pattern to copy.
+ * `MCP_ACCEPTED_ISSUERS` is a comma-separated grace list. It was built for a
+ * specific event, which has now happened: CLIENT_URL became
+ * `avails.citizeninfra.org` on 2026-08-04 (#150), and `avails.zhgnv.com` is
+ * listed here so tokens minted before that keep working. Without it the cutover
+ * would have invalidated every outstanding MCP token at once, presenting to
+ * every client as "token expired" — already the third distinct cause wearing
+ * that one message. Same shape as community-admin's CA_ACCEPTED_DIDS
+ * (community-admin#99).
+ *
+ * The old entry can be dropped once no live token still carries it. Tokens are
+ * short-lived, so that is a matter of days rather than adoption — but drop it
+ * on evidence, not on a date.
  */
 export function acceptedIssuers() {
   const extra = (process.env.MCP_ACCEPTED_ISSUERS || '')

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -47,7 +47,7 @@ export async function getClient() {
     throw new Error('ATPROTO_CLIENT_ID and ATPROTO_REDIRECT_URI must be set');
   }
 
-  // Derive base URL from the client ID URL (e.g. https://avails.zhgnv.com)
+  // Derive base URL from the client ID URL (e.g. https://avails.citizeninfra.org)
   const clientUri = new URL(clientId).origin;
 
   // Load the signing key from env var. Generate one with:

--- a/server/src/routes/responses.js
+++ b/server/src/routes/responses.js
@@ -17,7 +17,7 @@ const POLL_COLLECTION = 'chat.avails.scheduling.poll';
 // Legacy-path 503: only reachable when the service identity is unconfigured (or
 // when editing a pre-migration record that lives in the creator's repo) AND the
 // creator is signed out. The service path never 503s.
-const UNAVAILABLE_MSG = 'This poll is temporarily unavailable. The poll creator needs to sign back in at avails.zhgnv.com for responses to work. Please try again in a few minutes.';
+const UNAVAILABLE_MSG = 'This poll is temporarily unavailable. The poll creator needs to sign back in at avails.citizeninfra.org for responses to work. Please try again in a few minutes.';
 
 // Fetch with timeout — prevents hanging on slow PDS responses
 function fetchWithTimeout(url, options = {}, timeoutMs = 10000) {


### PR DESCRIPTION
Closes out the string half of #150. These were deliberately held back from [#159](https://github.com/Citizen-Infra/avails/pull/159) because each was coupled to the OAuth migration — which landed today, so they are now safe. **Two of them became actively wrong the moment it did.**

| File | Was | Now |
|---|---|---|
| `server/src/routes/responses.js` | tells a signed-out creator to sign in at the old host | the live host |
| `client/src/pages/Terms.jsx` | old address "serves the same service" | "now redirects here" |
| `client/src/pages/About.jsx` | `claude mcp add` against the old host | the live host |
| `server/.env.example` | OAuth pair on the old host | live host, plus `LEGACY_HOSTS` |
| `server/src/mcp/issuers.js` | describes the cutover as upcoming | records that it happened |
| `server/src/routes/auth.js` | example host in a comment | live host |
| `CLAUDE.md` | Deployment names the old custom domain | live host + the `LEGACY_HOSTS` note |
| `README.md` | "also serves the same app" | "permanently redirects here" |

The `responses.js` one is why the hold-back mattered. Until this morning it was **correct** — the callback was served from the old host and the session cookie is written host-only, so directing someone to the new host would have completed the OAuth round trip and landed them signed out with no error. Now the opposite is true: the old host 308s and cannot complete a sign-in there at all. A string that was right yesterday and wrong today, in both directions, for the same underlying reason.

`.env.example` also gains the constraint that caused it, stated so the next person configuring from it does not have to rediscover it:

```
# Both must name the SAME host as CLIENT_URL. The callback writes the session
# cookie host-only (auth.js, res.cookie with no domain), so a callback on one
# host and a CLIENT_URL on another lands the user signed out with no error.
```

## What keeps the old host on purpose

`server/test/corsOrigins.test.js` — it is the fixture for the grace-list case and should stay concrete. `docs/process-notes.md` and the superpowers specs — history, which should read as it was written.

## Gates

Full suite **213 passed**, `node --check` clean, `cd client && npm run build` clean.
