### PR TITLE
Fix poll links in emails and calendar invites (404s)

### DIFF
--- a/server/src/lib/pollUrl.js
+++ b/server/src/lib/pollUrl.js
@@ -1,0 +1,19 @@
+// The public URL of a poll page.
+//
+// One helper because this path is a contract with the client router — the route
+// is `/p/:did/:rkey` (client/src/App.jsx) and anything else falls through to the
+// catch-all NotFound route. The MCP tools built it correctly; the three REST
+// call sites had drifted to `/poll/`, so every scheduling email, every
+// cancellation email, and the URL embedded in both .ics files pointed at a
+// 404 (#130). A calendar invite outlives the email that carried it, so the dead
+// link stays in people's calendars.
+//
+// The trailing-slash strip is not decoration: CLIENT_URL is hand-entered in
+// Railway, and `https://host/` + `/p/...` would produce a double slash.
+// legacyHostRedirect.js strips it for the same reason.
+export function pollUrl(did, rkey) {
+  const base = String(process.env.CLIENT_URL || 'http://localhost:5173')
+    .trim()
+    .replace(/\/+$/, '');
+  return `${base}/p/${did}/${rkey}`;
+}

--- a/server/src/mcp/tools.js
+++ b/server/src/mcp/tools.js
@@ -9,6 +9,7 @@ import { assertMembership } from '../lib/membership.js';
 import { resolveListAvailability, resolveAvailabilityForDids } from './listMembers.js';
 import { bestCallSlots } from './availabilityOverlap.js';
 import { fetchCommunityConfig } from '../lib/communityConfig.js';
+import { pollUrl } from '../lib/pollUrl.js';
 
 const POLL_COLLECTION = 'chat.avails.scheduling.poll';
 const RESPONSE_COLLECTION = 'chat.avails.scheduling.response';
@@ -50,11 +51,6 @@ async function xrpcCall(oauthSession, method, body) {
     throw new Error(`XRPC ${method} failed (${response.status}): ${text}`);
   }
   return response.json();
-}
-
-function pollUrl(did, rkey) {
-  const base = process.env.CLIENT_URL || 'http://localhost:5173';
-  return `${base}/p/${did}/${rkey}`;
 }
 
 // Community config now comes from the shared lib/communityConfig.js helper

--- a/server/src/routes/polls.js
+++ b/server/src/routes/polls.js
@@ -7,6 +7,7 @@ import { sendEmail } from '../lib/email.js';
 import { composeEmail } from '../lib/email-template.js';
 import { deleteOpenMeetEvent } from './openmeet.js';
 import { fetchPollResponses } from '../lib/responseReads.js';
+import { pollUrl } from '../lib/pollUrl.js';
 import { publishToCommunityFeed } from '../mcp/tools.js';
 
 const router = Router();
@@ -127,9 +128,10 @@ router.get('/:did/:rkey', async (req, res, next) => {
     const { did, rkey } = req.params;
     const pds = await resolvePds(did);
 
-    // Fetch the poll record
-    const pollUrl = `${pds}/xrpc/com.atproto.repo.getRecord?repo=${encodeURIComponent(did)}&collection=${encodeURIComponent(POLL_COLLECTION)}&rkey=${encodeURIComponent(rkey)}`;
-    const pollRes = await fetchWithTimeout(pollUrl);
+    // Fetch the poll record. Named recordUrl, not pollUrl: this is the PDS
+    // getRecord endpoint, not the poll's page on the web.
+    const recordUrl = `${pds}/xrpc/com.atproto.repo.getRecord?repo=${encodeURIComponent(did)}&collection=${encodeURIComponent(POLL_COLLECTION)}&rkey=${encodeURIComponent(rkey)}`;
+    const pollRes = await fetchWithTimeout(recordUrl);
     if (!pollRes.ok) {
       return res.status(pollRes.status).json({ error: 'Poll not found' });
     }
@@ -264,13 +266,13 @@ router.put('/:did/:rkey/finalize', requireAuth, async (req, res, next) => {
     updatePollStatus(did, rkey, 'finalized');
 
     // Fetch responses for participant names and emails (creator + service, #42)
-    const pollUrl = `${process.env.CLIENT_URL || 'http://localhost:5173'}/poll/${did}/${rkey}`;
+    const url = pollUrl(did, rkey);
     const pollResponses = await fetchPollResponses(did, rkey);
 
     const participants = pollResponses.filter((r) => r.name).map((r) => r.name);
     const icsContent = generateIcs({
       poll: updatedRecord,
-      pollUrl,
+      pollUrl: url,
       did,
       rkey,
       participants,
@@ -297,7 +299,7 @@ router.put('/:did/:rkey/finalize', requireAuth, async (req, res, next) => {
           participants.length > 0 ? `Who answered the poll: ${participants.join(', ')}.` : null,
           'A calendar invite is attached, so this should appear in your calendar automatically.',
         ],
-        action: { label: 'View the poll', url: pollUrl },
+        action: { label: 'View the poll', url },
         footer:
           'You are receiving this because you answered this poll or were added to its notification list. No action is needed.',
       });
@@ -373,7 +375,7 @@ router.delete('/:did/:rkey/finalize', requireAuth, async (req, res, next) => {
     }
 
     // Best-effort: send cancellation emails with METHOD:CANCEL .ics
-    const pollUrl = `${process.env.CLIENT_URL || 'http://localhost:5173'}/poll/${did}/${rkey}`;
+    const url = pollUrl(did, rkey);
     const pollResponses = await fetchPollResponses(did, rkey);
 
     const participants = pollResponses.filter((r) => r.name).map((r) => r.name);
@@ -382,7 +384,7 @@ router.delete('/:did/:rkey/finalize', requireAuth, async (req, res, next) => {
     if (emailList.length > 0) {
       const cancelIcs = generateIcs({
         poll: snapshot,
-        pollUrl,
+        pollUrl: url,
         did,
         rkey,
         participants,
@@ -403,7 +405,7 @@ router.delete('/:did/:rkey/finalize', requireAuth, async (req, res, next) => {
           'Your calendar should remove it on its own, since a cancellation is attached.',
           'The poll is open again, so you can change your availability if your options have shifted.',
         ],
-        action: { label: 'Update your availability', url: pollUrl },
+        action: { label: 'Update your availability', url },
         footer:
           'You are receiving this because you answered this poll or were added to its notification list.',
       });

--- a/server/src/routes/responses.js
+++ b/server/src/routes/responses.js
@@ -5,6 +5,7 @@ import { validateResponseCreate } from '../middleware/validate.js';
 import { incrementResponseCount } from '../lib/pollIndex.js';
 import { sendEmail } from '../lib/email.js';
 import { composeEmail } from '../lib/email-template.js';
+import { pollUrl } from '../lib/pollUrl.js';
 import {
   isServiceConfigured, serviceCreateRecord, servicePutRecord, serviceDeleteRecord, serviceGetRecord,
 } from '../lib/serviceSession.js';
@@ -112,13 +113,16 @@ router.post('/:did/:rkey/responses', validateResponseCreate, async (req, res, ne
     // Fetch poll to check notifyAfter threshold and creator email
     try {
       const pds = await resolvePds(did);
-      const pollUrl = `${pds}/xrpc/com.atproto.repo.getRecord?repo=${encodeURIComponent(did)}&collection=${encodeURIComponent(POLL_COLLECTION)}&rkey=${encodeURIComponent(rkey)}`;
-      const pollRes = await fetchWithTimeout(pollUrl);
+      // recordUrl, not pollUrl: this is the PDS getRecord endpoint, not the
+      // poll's page on the web. Naming it pollUrl would shadow the imported
+      // helper in this scope and turn the call below into a TypeError.
+      const recordUrl = `${pds}/xrpc/com.atproto.repo.getRecord?repo=${encodeURIComponent(did)}&collection=${encodeURIComponent(POLL_COLLECTION)}&rkey=${encodeURIComponent(rkey)}`;
+      const pollRes = await fetchWithTimeout(recordUrl);
       if (pollRes.ok) {
         const pollData = await pollRes.json();
         const poll = pollData.value;
         if (poll.notifyAfter && newCount >= poll.notifyAfter && poll.creatorEmail) {
-          const viewUrl = `${process.env.CLIENT_URL || 'http://localhost:5173'}/poll/${did}/${rkey}`;
+          const viewUrl = pollUrl(did, rkey);
           const plural = (n) => (n !== 1 ? 's' : '');
           await sendEmail({
             to: poll.creatorEmail,

--- a/server/test/pollUrl.test.js
+++ b/server/test/pollUrl.test.js
@@ -1,0 +1,57 @@
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { pollUrl } from '../src/lib/pollUrl.js';
+
+const HOST = 'https://avails.citizeninfra.org';
+const DID = 'did:plc:abc123';
+const RKEY = '3kxyz';
+
+// The helper reads process.env on every call, so each test sets its own world.
+beforeEach(() => {
+  delete process.env.CLIENT_URL;
+});
+
+test('builds the path the client router actually serves', () => {
+  process.env.CLIENT_URL = HOST;
+  assert.equal(pollUrl(DID, RKEY), `${HOST}/p/${DID}/${RKEY}`);
+});
+
+test('the path matches a real route in the client router', () => {
+  // The bug this file exists for (#130): the server built `/poll/:did/:rkey`
+  // while the router only serves `/p/:did/:rkey`, so every scheduling email
+  // and every calendar invite linked to the catch-all NotFound route. Nothing
+  // in the server could notice, because the contract lives across a boundary
+  // the server never reads. So read it here.
+  const router = readFileSync(new URL('../../client/src/App.jsx', import.meta.url), 'utf8');
+  const routes = [...router.matchAll(/<Route\s+path="([^"]+)"/g)].map((m) => m[1]);
+
+  process.env.CLIENT_URL = HOST;
+  const path = new URL(pollUrl(DID, RKEY)).pathname;
+  // Turn each declared route into a matcher: `:param` accepts one segment.
+  const matches = routes.some((route) => {
+    if (route === '*') return false; // the NotFound catch-all is not a match
+    const pattern = new RegExp(`^${route.replace(/:[^/]+/g, '[^/]+')}$`);
+    return pattern.test(path);
+  });
+
+  assert.ok(
+    matches,
+    `pollUrl() produced ${path}, which no client route serves. Declared routes: ${routes.join(', ')}`
+  );
+});
+
+test('a trailing slash on CLIENT_URL does not produce a double slash', () => {
+  // CLIENT_URL is hand-entered in Railway and regularly carries one.
+  process.env.CLIENT_URL = `${HOST}/`;
+  assert.equal(pollUrl(DID, RKEY), `${HOST}/p/${DID}/${RKEY}`);
+});
+
+test('surrounding whitespace in CLIENT_URL is tolerated', () => {
+  process.env.CLIENT_URL = `  ${HOST}  `;
+  assert.equal(pollUrl(DID, RKEY), `${HOST}/p/${DID}/${RKEY}`);
+});
+
+test('an unset CLIENT_URL falls back to the vite dev server', () => {
+  assert.equal(pollUrl(DID, RKEY), `http://localhost:5173/p/${DID}/${RKEY}`);
+});


### PR DESCRIPTION
Closes #130.

The client router serves `/p/:did/:rkey` (`client/src/App.jsx`). Anything else falls through to the catch-all `NotFound` route. The MCP tools built that path correctly; the three REST call sites built `/poll/:did/:rkey`.

| Call site | What carried the dead link |
|---|---|
| `routes/responses.js` | "See who is available" in the creator's response-count email |
| `routes/polls.js` finalize | Schedule confirmation email, **and the URL written into the REQUEST `.ics`** |
| `routes/polls.js` unfinalize | Cancellation email, **and the CANCEL `.ics`** |

The calendar cases are the ones that persist. `pollUrl` goes into the event's `URL` property and its description, so the broken link lives in the recipient's calendar long after the email is gone. The Resend log shows 14 invites already sent.

## What changed

Lifts the working helper out of `mcp/tools.js` into `lib/pollUrl.js` so all four callers share one definition, and adds a trailing-slash strip because `CLIENT_URL` is hand-entered in Railway (`legacyHostRedirect.js` strips it for the same reason).

Two function-local `const pollUrl` values — the PDS `getRecord` endpoint, in each route file — are renamed `recordUrl`. In `responses.js` that one is in the enclosing scope of the new call, so leaving it would have shadowed the import and thrown `TypeError: pollUrl is not a function` at runtime.

## Verification

`pollUrl.test.js` reads the client router, extracts its declared `<Route path=...>` values, and asserts the generated path matches one of them (excluding the `*` catch-all). This contract lives across a boundary the server never reads, which is exactly why the drift went unnoticed — so the test crosses it.

Both behaviours were mutation-checked rather than assumed:

| Mutation | Result |
|---|---|
| Restore `/poll/` in the helper | router-match test fails |
| Remove the trailing-slash strip | trailing-slash test fails |

Full suite: 218 pass, 0 fail. CI syntax check clean.

## Follow-up not in this PR

`icsUidFor()` derives the UID host from `CLIENT_URL`, so invites sent before yesterday's host move carry `@avails.zhgnv.com` UIDs and a cancellation sent now would not match them in recipients' calendars. Evidence says this is not worth engineering around: one cancellation has ever been sent, and every affected event is in the past.
