### PR TITLE
GET /mcp returns 405 instead of the SPA shell

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,7 +150,11 @@ Phase 1 is list-scope only. `ca-community` scoping (private community-admin comm
 
 ## MCP endpoint
 
-Embedded `POST /mcp` JSON-RPC endpoint with ATProto OAuth (Smoke Signal pattern). Nine tools:
+Embedded `POST /mcp` JSON-RPC endpoint with ATProto OAuth (Smoke Signal pattern).
+
+`GET /mcp` returns **405** with `Allow: POST, DELETE`. A client may GET the endpoint to open a server-to-client SSE stream, and the Streamable HTTP spec allows only two answers: `Content-Type: text/event-stream`, or 405 to say there is no stream here. Avails never initiates messages, so 405 is the accurate one. Without that route the request fell through to the SPA fallback and returned `200 text/html`, which is neither — a client reads that as a stream that opened and closed instantly, and reconnects forever (#164).
+
+Nine tools:
 
 | Tool | Auth | Description |
 |------|------|-------------|

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -18,7 +18,7 @@ import { backfillCommunityFeedPublished } from './lib/pollIndex.js';
 import { cleanupExpiredSessions, sessions } from './lib/sessionStore.js';
 import { spaFallback } from './middleware/spaFallback.js';
 import mcpOauthRoutes from './mcp/oauth.js';
-import { handleMcp, handleMcpDelete } from './mcp/handler.js';
+import { handleMcp, handleMcpDelete, handleMcpGet } from './mcp/handler.js';
 import { pollOgHandler } from './lib/og.js';
 import { secretMatches, bearerFrom } from './lib/bearerAuth.js';
 
@@ -137,6 +137,12 @@ app.use('/mcp', mcpOauthRoutes);
 // budget. DELETE is session teardown, not a fan-out surface, so it's exempt.
 app.post('/mcp', mcpLimiter, handleMcp);
 app.delete('/mcp', handleMcpDelete);
+
+// GET /mcp is how a client opens a server-to-client SSE stream. We don't offer
+// one, and the spec's answer for that is 405 — not the SPA shell this used to
+// fall through to. Must be registered before express.static/spaFallback, and it
+// matches /mcp exactly so the OAuth sub-routes mounted above are untouched.
+app.get('/mcp', handleMcpGet);
 
 // Admin: clear all sessions. Logs every user out, so it is credentialed.
 //

--- a/server/src/mcp/handler.js
+++ b/server/src/mcp/handler.js
@@ -164,3 +164,27 @@ export async function handleMcp(req, res) {
 export function handleMcpDelete(req, res) {
   res.sendStatus(204);
 }
+
+/**
+ * GET /mcp — 405.
+ *
+ * A client may GET the MCP endpoint to open a server-to-client SSE stream. The
+ * Streamable HTTP spec gives a server exactly two allowed answers: return
+ * `Content-Type: text/event-stream`, or return 405 to say there is no stream
+ * here. Avails' MCP is request/response only — it never initiates messages —
+ * so 405 is the honest one.
+ *
+ * This route exists because without it the request fell through to the SPA
+ * fallback and got `200 text/html`, which is neither answer. A client cannot
+ * read a stream out of that and gets no error telling it to stop, so it
+ * reconnects forever: production ran a 2-3/s GET /mcp loop for hours on
+ * 2026-08-04, every request a 200.
+ *
+ * RFC 9110 requires the Allow header on a 405.
+ */
+export function handleMcpGet(req, res) {
+  res.set('Allow', 'POST, DELETE');
+  res.status(405).json({
+    error: 'This MCP endpoint does not offer an SSE stream. Use POST for JSON-RPC.',
+  });
+}

--- a/server/test/mcpGet405.test.js
+++ b/server/test/mcpGet405.test.js
@@ -1,0 +1,95 @@
+/**
+ * GET /mcp must return 405, not the SPA shell.
+ *
+ * MCP's Streamable HTTP transport lets a client open a server-to-client SSE
+ * stream with a GET to the MCP endpoint. The spec (2025-06-18, "Listening for
+ * Messages from the Server") is a MUST:
+ *
+ *   The server MUST either return `Content-Type: text/event-stream` in response
+ *   to this HTTP GET, or else return HTTP 405 Method Not Allowed, indicating
+ *   that the server does not offer an SSE stream at this endpoint.
+ *
+ * No GET route was registered for /mcp, so the request fell through to the SPA
+ * fallback and got `200 text/html`. That is neither branch of the MUST: the
+ * client sees a success, tries to read a stream, hits end-of-body immediately,
+ * and reconnects — with no 405 to tell it the endpoint has no stream. On
+ * 2026-08-04 production logged a continuous GET /mcp loop at 2-3/s that ran for
+ * hours and only stopped when the container was replaced.
+ *
+ * Avails' MCP is request/response only — it never initiates messages — so 405
+ * is the correct branch. RFC 9110 also requires an Allow header on a 405.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import { once } from 'node:events';
+
+import { handleMcpGet } from '../src/mcp/handler.js';
+
+describe('GET /mcp (MCP Streamable HTTP)', () => {
+  let server;
+  let port;
+
+  before(async () => {
+    const app = express();
+
+    // Mirrors index.js's mount order. A stand-in for mcpOauthRoutes rather than
+    // the real router: what is under test is Express's routing between a
+    // `use('/mcp', router)` mount and an exact `get('/mcp')`, and the stand-in
+    // exercises that faithfully without dragging in the OAuth module's env.
+    const oauthish = express.Router();
+    oauthish.get('/authorize', (req, res) => res.json({ route: 'authorize' }));
+    app.use('/mcp', oauthish);
+
+    app.get('/mcp', handleMcpGet);
+    app.post('/mcp', (req, res) => res.json({ route: 'rpc' }));
+
+    // The catch-all that used to answer GET /mcp.
+    app.get('*', (req, res) => res.type('html').send('<!doctype html>app shell'));
+
+    server = app.listen(0);
+    await once(server, 'listening');
+    port = server.address().port;
+  });
+
+  after(() => server?.close());
+
+  it('405s instead of serving the SPA shell', async () => {
+    const res = await fetch(`http://localhost:${port}/mcp`, {
+      headers: { Accept: 'text/event-stream' },
+      signal: AbortSignal.timeout(3000),
+    });
+    assert.equal(res.status, 405);
+    assert.doesNotMatch(res.headers.get('content-type') || '', /text\/html/);
+    assert.doesNotMatch(await res.text(), /app shell/);
+  });
+
+  it('carries an Allow header naming the methods that do work', async () => {
+    const res = await fetch(`http://localhost:${port}/mcp`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    const allow = res.headers.get('allow') || '';
+    assert.match(allow, /POST/);
+    assert.match(allow, /DELETE/);
+  });
+
+  it('leaves the OAuth sub-routes alone', async () => {
+    // The 405 must match /mcp exactly. Swallowing /mcp/authorize would break
+    // the whole MCP sign-in flow.
+    const res = await fetch(`http://localhost:${port}/mcp/authorize`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { route: 'authorize' });
+  });
+
+  it('leaves POST /mcp alone', async () => {
+    const res = await fetch(`http://localhost:${port}/mcp`, {
+      method: 'POST',
+      signal: AbortSignal.timeout(3000),
+    });
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { route: 'rpc' });
+  });
+});


### PR DESCRIPTION
Closes #164.

No GET route was registered for `/mcp`, so the request fell through `express.static` to `spaFallback` and returned `200 text/html`.

MCP's Streamable HTTP transport lets a client open a server-to-client SSE stream with a GET to the MCP endpoint, and the [spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports) allows exactly two answers:

> The server **MUST** either return `Content-Type: text/event-stream` in response to this HTTP GET, or else return HTTP 405 Method Not Allowed, indicating that the server does not offer an SSE stream at this endpoint.

`200 text/html` is neither. A client reads it as a stream that opened and ended immediately and reconnects — nothing in the exchange is an error, so there is no signal to back off on and no 405 to say the endpoint has no stream. Production ran a continuous `GET /mcp` loop at 2-3/s for hours on 2026-08-04, every request a 200, which stopped only when the container was replaced.

Avails' MCP is request/response only and never initiates messages, so 405 is the accurate branch rather than a shortcut. RFC 9110 requires `Allow` on a 405.

## Scope care

Registered as an exact `app.get('/mcp')`. The OAuth flow is mounted at `app.use('/mcp', mcpOauthRoutes)` above it, and swallowing `/mcp/authorize` would break MCP sign-in entirely — so that is a test, not an assumption.

## Verification

228 tests pass, up from 224. Then booted the real server and drove every affected route:

| Request | Result |
|---|---|
| `GET /mcp` (`Accept: text/event-stream`) | **405**, `Allow: POST, DELETE`, JSON body |
| `GET /mcp/authorize` | 400 — reached the route, params missing. Still routed. |
| `GET /.well-known/oauth-protected-resource` | 200 |
| `POST /mcp` `tools/list` | 200, tool list returned |
| `GET /p/:did/:rkey` | 200, SPA shell |

## Correction to what I said on #163

I described this on that PR as an ongoing flood at ~200k/day. That was over-stated. The burst was real and continuous through the window I sampled, but it stopped at the container replacement and has not resumed, and I had no basis for the daily extrapolation. #164 has the accurate account. The defect is still worth fixing — it is a spec MUST, and it is what makes such a loop unstoppable once a client starts one.
