### PR TITLE
CI: bump checkout and setup-node to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      # v4 of both ran on Node 20, which GitHub deprecated — every run was
+      # force-migrated to Node 24 and printed a warning. v5 is where each moved
+      # to Node 24 properly; v7 is current.
+      #
+      # Two breaking changes on the way here could have bitten and don't:
+      # setup-node v5 starts auto-caching when package.json carries a
+      # `packageManager` field (none of ours does), and checkout v7 blocks fork
+      # checkouts for `pull_request_target`/`workflow_run` (this workflow runs on
+      # `push`/`pull_request`). Re-check both if either of those changes.
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
       - name: Install client dependencies


### PR DESCRIPTION
Both actions were pinned at v4, which runs on Node 20. GitHub deprecated that, so every CI run this session printed:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`, `actions/setup-node@v4`.

v5 is where each action moved to Node 24 properly; v7 is current.

## Breaking changes checked, not assumed

| Version | Breaking change | Applies here? |
|---|---|---|
| `checkout@v5` | Node 24 runtime; runner ≥ v2.327.1 | No — `ubuntu-latest` is well past that |
| `checkout@v6` | Credentials persisted to a separate file | No — nothing reads the token beyond checkout |
| `checkout@v7` | Blocks fork checkout for `pull_request_target` / `workflow_run` | No — this workflow triggers on `push` / `pull_request` |
| `setup-node@v5` | **Auto-caches when `package.json` has a `packageManager` field** | No — absent from root, `client/`, and `server/` |
| `setup-node@v6` | Auto-caching narrowed to npm only | Narrows the above; still inert |
| `setup-node@v7` | ESM migration, new cache outputs | No |

The `setup-node@v5` one is the only entry that would have changed behaviour silently, which is why I checked the package.json files rather than reasoning about it.

The two conditions that would make this worth re-deriving — adding a `packageManager` field, or adding a `pull_request_target`/`workflow_run` trigger — are recorded in a comment in the workflow.

## Verification

The PR's own CI run is the test: it executes the new actions before this reaches `main`. YAML parses, 7 steps, both `uses` resolving to `@v7`.

## Not in this PR

The workflow sets no `cache:` on setup-node, so npm dependencies are re-downloaded on every run. Worth adding, but it is a behaviour change to the build rather than a deprecation fix, and it belongs with a look at the `npm install` vs `npm ci` inconsistency already tracked in #123.
