### PR TITLE
CI: npm ci for the client too, plus dependency caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,22 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          # Read from .node-version rather than repeating 22 here. The file
+          # already existed and this duplicated it, which is one edit away from
+          # CI and local dev building on different Node without anyone noticing.
+          node-version-file: .node-version
+          # Both workspaces — each has its own lockfile, and caching only one
+          # would silently leave the other reinstalling from the network.
+          cache: npm
+          cache-dependency-path: |
+            client/package-lock.json
+            server/package-lock.json
+      # npm ci, not npm install (#123). It installs exactly the lockfile, so a
+      # transitive bump cannot quietly make CI test something other than what
+      # deploys, and it FAILS on lockfile drift rather than papering over it —
+      # which is the point, not a side effect.
       - name: Install client dependencies
-        run: cd client && npm install
+        run: cd client && npm ci
       - name: Build client
         run: cd client && npm run build
       - name: Install server dependencies


### PR DESCRIPTION
Closes #123.

The client installed with `npm install` while the server used `npm ci` — an artifact of #111, which added the server steps and deliberately left the pre-existing client step alone to keep that diff scoped.

`npm ci` installs exactly the lockfile, so a transitive bump cannot quietly make CI test something other than what deploys, and it **fails on lockfile drift** rather than papering over it. That failure is the feature.

## Checked the way the issue asked

> Worth a quick `npm ci --dry-run` in `client/` first to confirm the lockfile is in sync

```
$ cd client && npm ci --dry-run
up to date in 4s
```

In sync, so this will not turn the build red on merge.

## Two more in the same block

Both remove a way for this workflow to drift silently, which is the same failure the issue is about:

**`node-version-file: .node-version` instead of a hardcoded `22`.** The file already existed and the workflow duplicated its value — one edit away from CI and local dev building on different Node with nobody noticing. Same change I just made in `my-community` for the same reason.

**`cache: npm` over both lockfiles.** There was no dependency caching at all, so every run reinstalled from the network. Caching only one workspace would have quietly left the other doing it, so both paths are listed:

```yaml
cache: npm
cache-dependency-path: |
  client/package-lock.json
  server/package-lock.json
```

## Verification

The PR's own CI run is the test — this workflow runs on `pull_request`, so it exercises every line changed here before merge. Watch for the client install step succeeding under `npm ci` and the cache being populated on the first run (it will report a miss; the hit shows up on the next).
