### PR TITLE
Name the standing-availability page for what it is: /standing, "Standing availability"

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,4 +1,4 @@
-import { Routes, Route, Link } from 'react-router'
+import { Routes, Route, Link, Navigate } from 'react-router'
 import ErrorBoundary from './components/ErrorBoundary'
 import Landing from './pages/Landing'
 import PollView from './pages/PollView'
@@ -25,7 +25,14 @@ export default function App() {
         <Route path="/about" element={<About />} />
         <Route path="/privacy" element={<Privacy />} />
         <Route path="/terms" element={<Terms />} />
-        <Route path="/availability" element={<ErrorBoundary><StandingAvailability /></ErrorBoundary>} />
+        <Route path="/standing" element={<ErrorBoundary><StandingAvailability /></ErrorBoundary>} />
+        {/* Everything in Avails is availability — the grid, a response, the
+            heatmap — so /availability named this page with the one word that
+            distinguishes it from nothing. /standing names what is actually
+            different about it: it outlives any single poll. Renamed before the
+            feature was announced, so no shared link could break; the redirect
+            is here for links already pasted somewhere internal. */}
+        <Route path="/availability" element={<Navigate to="/standing" replace />} />
         <Route path="/p/:did/:rkey" element={<ErrorBoundary><PollView /></ErrorBoundary>} />
         <Route path="*" element={<NotFound />} />
       </Routes>

--- a/client/src/pages/Landing.jsx
+++ b/client/src/pages/Landing.jsx
@@ -79,8 +79,13 @@ export default function Landing() {
             <span className="text-xl font-bold tracking-tight text-[#1a1a1a]">avails</span>
           </a>
           <div className="flex items-center gap-3 sm:gap-6 min-w-0">
+            {/* "Standing availability", not "Availability": the page's own h1
+                says the former, and so does the link to it further down this
+                page. Everything here is availability, so the bare noun named
+                the destination with the one word that told you nothing about
+                it. nowrap because two words must not wrap in a 64px header. */}
             {session?.did && (
-              <a href="/standing" className="hidden sm:block text-base text-[#6b6560] hover:text-[#1a1a1a] transition-colors">Availability</a>
+              <a href="/standing" className="hidden sm:block whitespace-nowrap text-base text-[#6b6560] hover:text-[#1a1a1a] transition-colors">Standing availability</a>
             )}
             <a href="/about" className="hidden sm:block text-base text-[#6b6560] hover:text-[#1a1a1a] transition-colors">About</a>
             <AuthButton />

--- a/client/src/pages/Landing.jsx
+++ b/client/src/pages/Landing.jsx
@@ -80,7 +80,7 @@ export default function Landing() {
           </a>
           <div className="flex items-center gap-3 sm:gap-6 min-w-0">
             {session?.did && (
-              <a href="/availability" className="hidden sm:block text-base text-[#6b6560] hover:text-[#1a1a1a] transition-colors">Availability</a>
+              <a href="/standing" className="hidden sm:block text-base text-[#6b6560] hover:text-[#1a1a1a] transition-colors">Availability</a>
             )}
             <a href="/about" className="hidden sm:block text-base text-[#6b6560] hover:text-[#1a1a1a] transition-colors">About</a>
             <AuthButton />
@@ -100,7 +100,7 @@ export default function Landing() {
             <div>
               <div className="flex items-center justify-between gap-3 mb-4">
                 <h2 className="text-xl font-semibold text-[#1a1a1a] tracking-tight">My polls</h2>
-                <a href="/availability" className="text-sm font-medium text-[#0d9488] hover:text-[#0f766e] transition-colors">
+                <a href="/standing" className="text-sm font-medium text-[#0d9488] hover:text-[#0f766e] transition-colors">
                   Set standing availability →
                 </a>
               </div>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -147,6 +147,7 @@ A finalized poll can carry a `meetingUrl` — a video call link, on the poll rec
 ### Pages
 - `Landing.jsx` — hero (unauthenticated) or My Polls + PollCreator (authenticated)
 - `PollView.jsx` — main poll page: grid + responses + scheduling
+- `StandingAvailability.jsx` — **`/standing`** — publish when you are generally free for a group, once, independent of any poll. Was `/availability` until 2026-08-06: every part of this product is availability (the grid, a response, the heatmap), so that path named the page with the one word that distinguished it from nothing, while saying nothing about what is actually different — that it outlives any single poll. Renamed before the feature was announced, so no shared link could break. `/availability` still redirects. Note the REST API `/api/availability` is unaffected and keeps its name.
 - `About.jsx` — Citizen Infra ecosystem info
 - `Privacy.jsx`, `Terms.jsx` — legal pages (required for Google OAuth consent screen)
 


### PR DESCRIPTION
Every part of this product is availability. The grid is availability, a response is availability, the heatmap is availability. So both the path `/availability` and the nav label "Availability" named this page with the one word that distinguishes it from nothing — and said nothing about what is actually different about it, which is that it **outlives any single poll**. Read cold, that path suggests a directory, or a help page about the concept.

The path also broke the pattern the other routes follow: `/p/:did/:rkey` says "a poll, this one"; `/availability` says a category.

## Two changes

**Route: `/availability` → `/standing`.** Names the distinguishing property. `/availability` still redirects.

**Nav label: "Availability" → "Standing availability".** This is a consistency fix rather than a naming choice — the page's own `<h1>` already says "Standing availability", and so does the inline link further down `Landing`. The header nav was the single place out of step, and the only instance of the bare label in the client. `whitespace-nowrap` so two words can't wrap inside the 64px header.

## Why now

This is the cheapest it will ever be. The feature shipped yesterday and **has not been announced**, so there are no shared links to break and no bookmarks to strand. After the announcement it costs a redirect plus stale links in someone's chat history.

## What is deliberately not renamed

- `/api/availability` — the REST API
- `chat.avails.scheduling.availability` — the lexicon
- every server module and validator

Those name **the record**, and "availability" is exactly the right word for it. Only the page route and its label were wrong, because they name a place a person goes.

## External consumers, checked before moving it

My Community writes standing availability **straight to the member's own PDS** (`extension/src/store/availability.js`: "no avails API, no community-admin") and ships its own capture strip, so nothing outside this repo links to the page. The in-repo references were the route and two links on `Landing`.

## Verification

Client build passes; the Impeccable mechanical detector returns clean on both changed files.

**One limit worth stating:** I did not screenshot the new label, because that nav item only renders when `session?.did` is set and a static headless build shows the signed-out header. I checked the fit by measurement instead — at the `sm` breakpoint the container is ~592px and the header's content comes to roughly 440px, so there is comfortable room, and `whitespace-nowrap` removes any wrap risk. Worth an eyeball on the real signed-in page after deploy.

## Also

`docs/architecture.md`'s Pages list was missing `StandingAvailability.jsx` entirely — an omission from the Phase 1 work. Added with the new path and the reason for it.