### PR TITLE
Refuse a malformed booking window instead of reporting no availability

### DIFF
--- a/server/src/mcp/tools.js
+++ b/server/src/mcp/tools.js
@@ -1076,6 +1076,30 @@ async function scheduleCall(
   if (!window || !window.start || !window.end) {
     throw new Error('window ({start, end}) is required');
   }
+  // Shape-checked, because a malformed window does not fail — it produces ZERO
+  // candidate slots, which this tool then reports as `fallback: create_poll`
+  // with "no overlapping availability found", and community-admin announces to
+  // members as "we could not find a time that worked for everyone who replied".
+  // A caller bug, blamed on the participants, in public.
+  //
+  // That is exactly how it went: community-admin sent full ISO timestamps for
+  // fourteen months. eachDateInRange splits on '-', so Number('07T00:00:00.000Z')
+  // was NaN, the range collapsed to one unusable entry, and no weekly window
+  // could ever match. Not one call-proposal ever booked, and nothing anywhere
+  // said why (community-admin#129, found 2026-08-06).
+  //
+  // Same rule as assertResolvableScope: "nobody is free" and "you asked the
+  // wrong question" must never produce the same answer.
+  for (const [field, value] of [['start', window.start], ['end', window.end]]) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(String(value))) {
+      throw new Error(
+        `window.${field} must be a YYYY-MM-DD date, got "${value}". A date-time is not accepted: it silently yields no candidate slots.`
+      );
+    }
+  }
+  if (window.end < window.start) {
+    throw new Error(`window.end (${window.end}) is before window.start (${window.start})`);
+  }
   if (!title) {
     throw new Error('title is required');
   }

--- a/server/test/scheduleCall.test.js
+++ b/server/test/scheduleCall.test.js
@@ -278,6 +278,57 @@ describe('schedule_call', () => {
   // must name the missing argument: resolving zero members instead would be
   // reported as "nobody has published availability", sending the organizer to
   // chase a coverage problem that does not exist.
+  // The failure this catches is not "it errored" — it is that a malformed
+  // window produced ZERO candidate slots, which surfaced as a fallback with
+  // "no overlapping availability found" and was announced to members as though
+  // nobody could make it. community-admin sent ISO timestamps for fourteen
+  // months and not one call-proposal ever booked.
+  it('(w1) an ISO date-time window is refused, rather than silently yielding no slots', async () => {
+    resetHooks();
+
+    await assert.rejects(
+      () => callTool('schedule_call', {
+        scope: LIST_URI,
+        durationMinutes: 60,
+        window: { start: '2026-07-21T00:00:00.000Z', end: '2026-07-28T00:00:00.000Z' },
+        title: 'Weekly sync',
+      }, SERVICE),
+      (err) => {
+        assert.match(err.message, /YYYY-MM-DD/);
+        // The reason must name the silent failure, or the next caller "fixes"
+        // it by loosening the check.
+        assert.match(err.message, /no candidate slots/);
+        return true;
+      }
+    );
+    assert.deepEqual(fetchCalls, []);
+  });
+
+  it('(w2) a plain date window is accepted', async () => {
+    resetHooks();
+    resolveListAvailabilityImpl = async () => [member('did:plc:alice', 'auto'), member('did:plc:bob', 'auto')];
+    bestCallSlotsImpl = () => [
+      { slot: '2026-07-21T14:00', participants: ['did:plc:alice', 'did:plc:bob'], count: 2 },
+    ];
+
+    const result = JSON.parse(await callTool('schedule_call', {
+      scope: LIST_URI, durationMinutes: 60,
+      window: { start: '2026-07-21', end: '2026-07-28' }, title: 'Weekly sync',
+    }, SERVICE));
+    assert.equal(result.booked, true);
+  });
+
+  it('(w3) a backwards window is refused', async () => {
+    resetHooks();
+    await assert.rejects(
+      () => callTool('schedule_call', {
+        scope: LIST_URI, durationMinutes: 60,
+        window: { start: '2026-07-28', end: '2026-07-21' }, title: 'Weekly sync',
+      }, SERVICE),
+      /before window\.start/
+    );
+  });
+
   it('(e) a ca-community scope without voterDids fails naming the missing argument, before touching resolveListAvailability', async () => {
     resetHooks();
     // resolveListAvailabilityImpl left as the "should not be called" throw.


### PR DESCRIPTION
The half of Citizen-Infra/community-admin#129 that stops it recurring from any caller.

## A malformed window doesn't fail — it reports that nobody is free

`eachDateInRange` parses `YYYY-MM-DD` by splitting on `-`. Anything else produces zero candidate slots, and `schedule_call` then answers:

```json
{"booked": false, "fallback": "create_poll", "reason": "No overlapping availability found between …"}
```

community-admin announces that to the community as *"We could not find a time that worked for everyone who replied."* A caller bug, blamed on the participants, in public.

## It already happened, for as long as the trigger has existed

community-admin sent `new Date(...).toISOString()`. `Number("07T00:00:00.000Z")` is `NaN`, so `weekdayOf` was `NaN` and no `pattern.weekly` entry could match. `addDaysToDateStr` returned `"NaN-NaN-NaN"`, which sorts above the end date and quietly ends the loop after one iteration rather than hitting the 10,000 guard — twelve days collapsed to one unusable entry.

**Not one call-proposal has ever booked.** Both test suites were green the whole time, because each side tested in its own format: ours passes `{start:'2026-07-21'}`, theirs asserted the ISO string went out. Nothing compared them. Found by running the chain end to end in production on 2026-08-06 with two real availability records.

## The change

Shape-check `window.start` / `window.end` against `YYYY-MM-DD` and throw naming the field and the value, plus reject a backwards window — which yields nothing for the same reason.

**Deliberately strict rather than normalising a date-time.** Leniency at this boundary is what let the mismatch live this long, and the caller is being fixed anyway. A rejected booking retries — `fire()` treats a throw as "could not ask", leaves `outcome` NULL and tries again — whereas a wrong one gets announced.

The error text names the silent failure, not just the format, so the next person to hit it doesn't "fix" it by loosening the check.

This is the same rule already written into `assertResolvableScope`: **"nobody is free" and "you asked the wrong question" must never produce the same answer.** The scope had that guard; the window did not.

## Tests

29 pass. Three new: an ISO date-time is refused, a plain date books, a backwards window is refused. Mutating the shape check away turns the first red.

Committed through a worktree — the main checkout has unrelated in-flight work on `polls.js`, `validate.js` and the client, which this deliberately doesn't touch.