### PR TITLE
Meeting links in the UI, and a route for adding one later

### DIFF
--- a/client/src/components/MeetingLinkField.jsx
+++ b/client/src/components/MeetingLinkField.jsx
@@ -1,0 +1,85 @@
+import { useId } from 'react'
+import { Input } from '@/components/ui/input'
+
+// The video call link for a scheduled meeting (#19). Used in two places that
+// need identical validation, affordances and copy: the scheduling bar, where
+// the link is set as part of picking the time, and the result card, where it is
+// added or changed afterwards.
+//
+// The Jitsi room is OFFERED, never pre-filled. A room needs no account, so
+// suggesting one is nearly free — but assuming one presumes the meeting is
+// online, and plenty of community meetings are in a room with chairs. Avails
+// finds times; it does not decide how a group meets.
+export default function MeetingLinkField({
+  value,
+  onChange,
+  suggestion,
+  error,
+  disabled = false,
+  autoFocus = false,
+}) {
+  const id = useId()
+  const errorId = `${id}-error`
+  const hasValue = value.trim().length > 0
+
+  return (
+    <div className="space-y-1.5">
+      <label htmlFor={id} className="block text-sm font-medium text-[#6b6560]">
+        Meeting link <span className="font-normal text-[#a09a94]">(optional)</span>
+      </label>
+
+      <Input
+        id={id}
+        type="url"
+        inputMode="url"
+        autoComplete="off"
+        spellCheck={false}
+        autoFocus={autoFocus}
+        disabled={disabled}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="https://"
+        aria-invalid={error ? true : undefined}
+        aria-describedby={error ? errorId : undefined}
+        className="h-10 border-[#d8d4cf] bg-[#faf9f6] text-[#1a1a1a] placeholder:text-[#a09a94]"
+      />
+
+      <div className="flex items-center gap-3 min-h-5">
+        {!hasValue && suggestion && (
+          <button
+            type="button"
+            onClick={() => onChange(suggestion)}
+            disabled={disabled}
+            className="text-sm text-[#0d9488] hover:text-[#0f766e] underline underline-offset-2 transition-colors disabled:opacity-50"
+          >
+            Use a Jitsi room
+          </button>
+        )}
+        {hasValue && (
+          <button
+            type="button"
+            onClick={() => onChange('')}
+            disabled={disabled}
+            className="text-sm text-[#6b6560] hover:text-[#1a1a1a] underline underline-offset-2 transition-colors disabled:opacity-50"
+          >
+            Clear
+          </button>
+        )}
+        {/* The server is the authority on what a valid link is, so its message
+            is shown verbatim rather than re-worded here. */}
+        {error && (
+          <p id={errorId} role="alert" className="text-sm text-[#b91c1c]">
+            {error}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// Deterministic from the poll's rkey, so the same poll always suggests the same
+// room and a participant who saved the link still lands in it. Jitsi creates a
+// room on first join, so naming one is all it takes.
+export function jitsiSuggestionFor(rkey) {
+  return `https://meet.jit.si/avails-${encodeURIComponent(rkey)}`
+}

--- a/client/src/components/SchedulingGrid.jsx
+++ b/client/src/components/SchedulingGrid.jsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback, useMemo, useEffect } from 'react'
 import { cn } from '@/lib/utils'
+import MeetingLinkField from './MeetingLinkField'
 import '../styles/avail-grid.css'
 
 /**
@@ -72,6 +73,12 @@ export default function SchedulingGrid({
   chosenCalendarId,           // string | 'none'
   onChooseCalendar,           // (id: string | 'none') => void
   onConnectGoogle,            // () => void — opens OAuth with events scope
+  // Meeting link (#19). Set here so the FIRST invite already carries it; the
+  // result card handles adding one later. Omit onMeetingUrlChange to hide the
+  // field entirely.
+  meetingUrl = '',            // string — controlled by the parent
+  onMeetingUrlChange,         // ((v: string) => void) | undefined
+  jitsiSuggestion,            // string — the room offered, never pre-filled
 }) {
   const times = useMemo(
     () => generateSlots(dates, timeRange, slotMinutes),
@@ -250,6 +257,22 @@ export default function SchedulingGrid({
           </div>
         </div>
       </div>
+
+      {/* Below the teal bar rather than inside it, for two reasons: the bar is
+          already a dense control strip that would crowd at the sm breakpoint,
+          and white body text on Gather Teal measures 3.75:1 — fine for the
+          bar's large text and buttons, under AA for a field label and an error
+          message. On Paper Cream those clear it comfortably. */}
+      {onMeetingUrlChange && (
+        <div className="max-w-md">
+          <MeetingLinkField
+            value={meetingUrl}
+            onChange={onMeetingUrlChange}
+            suggestion={jitsiSuggestion}
+            disabled={confirmLoading}
+          />
+        </div>
+      )}
 
       {error && <p className="text-sm text-red-600">{error}</p>}
 

--- a/client/src/lib/api.js
+++ b/client/src/lib/api.js
@@ -21,7 +21,11 @@ export async function createPoll(data) { return apiFetch('/api/polls', { method:
 export async function getPoll(did, rkey) { return apiFetch(`/api/polls/${did}/${rkey}`); }
 export async function submitResponse(did, rkey, data) { return apiFetch(`/api/polls/${did}/${rkey}/responses`, { method: 'POST', body: JSON.stringify(data) }); }
 export async function updateResponse(did, rkey, responseRkey, data) { return apiFetch(`/api/polls/${did}/${rkey}/responses/${responseRkey}`, { method: 'PUT', body: JSON.stringify(data) }); }
-export async function finalizePoll(did, rkey, finalTime, finalDuration, notifyEmails) { return apiFetch(`/api/polls/${did}/${rkey}/finalize`, { method: 'PUT', body: JSON.stringify({ finalTime, finalDuration, notifyEmails }) }); }
+export async function finalizePoll(did, rkey, finalTime, finalDuration, notifyEmails, meetingUrl) { return apiFetch(`/api/polls/${did}/${rkey}/finalize`, { method: 'PUT', body: JSON.stringify({ finalTime, finalDuration, notifyEmails, ...(meetingUrl !== undefined ? { meetingUrl } : {}) }) }); }
+// Changing the link on an already-scheduled poll re-issues the calendar invite,
+// which is why it is not just another finalize: the server sends "the link
+// changed", not "the meeting is booked". Unchanged values send nothing at all.
+export async function setMeetingLink(did, rkey, meetingUrl) { return apiFetch(`/api/polls/${did}/${rkey}/meeting-link`, { method: 'PUT', body: JSON.stringify({ meetingUrl }) }); }
 export async function unfinalizePoll(did, rkey) { return apiFetch(`/api/polls/${did}/${rkey}/finalize`, { method: 'DELETE' }); }
 export async function updatePoll(did, rkey, data) { return apiFetch(`/api/polls/${did}/${rkey}`, { method: 'PUT', body: JSON.stringify(data) }); }
 export async function getCommunities() { return apiFetch('/api/communities'); }

--- a/client/src/pages/PollView.jsx
+++ b/client/src/pages/PollView.jsx
@@ -1,7 +1,7 @@
 import Logo from '@/components/Logo'
 import { useEffect, useState, useCallback, useMemo } from 'react'
 import { useParams } from 'react-router'
-import { getPoll, getSession, submitResponse, updateResponse, finalizePoll, unfinalizePoll, deleteResponse, publishToOpenMeet, publishToCommunityFeed, getOpenMeetAvailability, setGoogleCalendarEvent, getCommunities, updatePoll } from '@/lib/api'
+import { getPoll, getSession, submitResponse, updateResponse, finalizePoll, unfinalizePoll, deleteResponse, publishToOpenMeet, publishToCommunityFeed, getOpenMeetAvailability, setGoogleCalendarEvent, getCommunities, updatePoll, setMeetingLink } from '@/lib/api'
 import {
   isGoogleConfigured,
   requestGoogleAccess,
@@ -24,8 +24,22 @@ import DeletePollDialog from '@/components/DeletePollDialog'
 import DeleteResponseDialog from '@/components/DeleteResponseDialog'
 import UnscheduleDialog from '@/components/UnscheduleDialog'
 import GuestModal from '@/components/GuestModal'
+import MeetingLinkField, { jitsiSuggestionFor } from '@/components/MeetingLinkField'
 
 const EMPTY_SET = new Set()
+
+// The host of a meeting link, for display beside "Join the call". A Zoom link
+// carrying a passcode query string is unreadable in full; the anchor keeps the
+// whole URL. Falls back to the raw value if it will not parse — the server
+// validated it, so an unparseable one reaching here means something is wrong,
+// and hiding it would be worse than showing it.
+function hostOf(url) {
+  try {
+    return new URL(url).host
+  } catch {
+    return url
+  }
+}
 
 export default function PollView() {
   const { did, rkey } = useParams()
@@ -73,6 +87,12 @@ export default function PollView() {
   const [showGuestModal, setShowGuestModal] = useState(false)
   const [justSubmitted, setJustSubmitted] = useState(false) // transient post-submit confirmation
   const [calendarCleanupWarning, setCalendarCleanupWarning] = useState(null) // best-effort google-delete notice
+  // Meeting link (#19). `draft` is what the field holds in either place;
+  // `editing` is only the result card's inline editor being open.
+  const [meetingUrlDraft, setMeetingUrlDraft] = useState('')
+  const [editingMeetingUrl, setEditingMeetingUrl] = useState(false)
+  const [meetingUrlSaving, setMeetingUrlSaving] = useState(false)
+  const [meetingUrlError, setMeetingUrlError] = useState(null)
   const [openmeetUrl, setOpenmeetUrl] = useState(null)
   const [publishingToOpenMeet, setPublishingToOpenMeet] = useState(false)
   const [openmeetError, setOpenmeetError] = useState(null)
@@ -465,10 +485,14 @@ export default function PollView() {
       const finalDuration = schedulingSlots.length * mins
       const notifyEmails = [...new Set(responses.filter(r => r.email).map(r => r.email))]
 
-      // 1) PDS finalize + .ics emails. Source of truth.
-      await finalizePoll(did, rkey, finalTime, finalDuration, notifyEmails)
+      // 1) PDS finalize + .ics emails. Source of truth. The meeting link rides
+      // along so the FIRST invite already carries it — adding one afterwards
+      // costs everyone a second email.
+      const link = meetingUrlDraft.trim()
+      await finalizePoll(did, rkey, finalTime, finalDuration, notifyEmails, link || undefined)
       setSchedulingMode(false)
       setSchedulingSlots([])
+      setMeetingUrlDraft('')
 
       // 2) Optional Google Calendar insert. Independent — never rolls back the schedule.
       if (chosenCalendarId !== 'none' && googleToken) {
@@ -481,6 +505,32 @@ export default function PollView() {
     } finally {
       setSchedulingLoading(false)
     }
+  }
+
+  // Save a link on an ALREADY scheduled poll. Separate from finalize because
+  // the server sends a different message for it: "the link changed", not "the
+  // meeting is booked". An unchanged value is a no-op there, so opening the
+  // editor and closing it again mails nobody.
+  async function handleSaveMeetingLink() {
+    if (meetingUrlSaving) return
+    setMeetingUrlSaving(true)
+    setMeetingUrlError(null)
+    try {
+      await setMeetingLink(did, rkey, meetingUrlDraft.trim())
+      setEditingMeetingUrl(false)
+      fetchData()
+    } catch (err) {
+      // The server owns what counts as a valid link, so show its wording.
+      setMeetingUrlError(err.message || 'Could not save the meeting link')
+    } finally {
+      setMeetingUrlSaving(false)
+    }
+  }
+
+  function openMeetingLinkEditor() {
+    setMeetingUrlDraft(poll?.meetingUrl || '')
+    setMeetingUrlError(null)
+    setEditingMeetingUrl(true)
   }
 
   async function retryCalendarInsert() {
@@ -752,6 +802,81 @@ export default function PollView() {
               {poll.finalDuration && <span className="text-[#6b6560] text-lg ml-2">({poll.finalDuration} min)</span>}
             </p>
 
+            {/* Join, directly under the time. It is the one line someone opens
+                this page to find five minutes before the call, so it sits above
+                the calendar and OpenMeet rows rather than among them.
+                Confirmed Green, not Gather Teal: teal inside this green card
+                would put two brand voices in one component. */}
+            {poll.meetingUrl && !editingMeetingUrl && (
+              <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                <a
+                  href={poll.meetingUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group inline-flex items-baseline gap-2 text-lg font-semibold text-[#15803d] hover:text-[#166534] no-underline"
+                >
+                  <span className="underline underline-offset-4 decoration-2">Join the call</span>
+                  {/* The host alone, because a Zoom link carrying a passcode
+                      query string is unreadable; the anchor keeps all of it.
+                      Explicitly not underlined — inside the anchor it would
+                      inherit one and read as a second, competing link. */}
+                  <span className="text-sm font-normal text-[#6b6560] no-underline break-all">
+                    {hostOf(poll.meetingUrl)}
+                  </span>
+                </a>
+                {isCreator && (
+                  <button
+                    onClick={openMeetingLinkEditor}
+                    className="text-sm text-[#6b6560] hover:text-[#1a1a1a] underline underline-offset-2 transition-colors"
+                  >
+                    Edit
+                  </button>
+                )}
+              </div>
+            )}
+
+            {isCreator && !poll.meetingUrl && !editingMeetingUrl && (
+              <button
+                onClick={openMeetingLinkEditor}
+                className="text-sm font-medium text-[#15803d] hover:text-[#166534] underline underline-offset-2 transition-colors"
+              >
+                Add a meeting link
+              </button>
+            )}
+
+            {isCreator && editingMeetingUrl && (
+              <div className="space-y-3 max-w-md">
+                <MeetingLinkField
+                  value={meetingUrlDraft}
+                  onChange={setMeetingUrlDraft}
+                  suggestion={jitsiSuggestionFor(rkey)}
+                  error={meetingUrlError}
+                  disabled={meetingUrlSaving}
+                  autoFocus
+                />
+                <div className="flex items-center gap-3">
+                  <Button
+                    size="sm"
+                    onClick={handleSaveMeetingLink}
+                    disabled={meetingUrlSaving}
+                    className="bg-[#15803d] text-white hover:bg-[#166534]"
+                  >
+                    {meetingUrlSaving ? 'Saving…' : 'Save link'}
+                  </Button>
+                  <button
+                    onClick={() => { setEditingMeetingUrl(false); setMeetingUrlError(null) }}
+                    disabled={meetingUrlSaving}
+                    className="text-sm text-[#6b6560] hover:text-[#1a1a1a] transition-colors disabled:opacity-50"
+                  >
+                    Cancel
+                  </button>
+                </div>
+                <p className="text-sm text-[#6b6560]">
+                  Everyone who answered gets an updated invite. The time does not change.
+                </p>
+              </div>
+            )}
+
             {googleEventLink && (
               <p className="text-sm text-[#0d9488]">
                 Added to {googleEventLink.calendarSummary} —{' '}
@@ -930,6 +1055,9 @@ export default function PollView() {
                 chosenCalendarId={chosenCalendarId}
                 onChooseCalendar={setChosenCalendarId}
                 onConnectGoogle={() => connectGoogleCalendar({ forEvent: true })}
+                meetingUrl={meetingUrlDraft}
+                onMeetingUrlChange={setMeetingUrlDraft}
+                jitsiSuggestion={jitsiSuggestionFor(rkey)}
               />
             ) : (
               <AvailGrid

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,6 +142,12 @@ A finalized poll can carry a `meetingUrl` — a video call link, on the poll rec
 
 **Unfinalize clears it**, alongside `finalTime`/`finalDuration`/`openmeetEventSlug`/`googleEventId`. The link belongs to the meeting, not to the poll; leaving it behind would hand the next finalize a stale room from a decision that was reversed.
 
+**Two places set it, and they are different routes on purpose.** At schedule time the link rides along on `PUT /:did/:rkey/finalize`, so the first invite already carries it. Afterwards it goes through **`PUT /:did/:rkey/meeting-link`** (`validateMeetingLink`, creator-only, 400 on a poll with no `finalTime`). Reusing finalize for the second case would work mechanically — it re-sends, and the frozen UID means calendars update in place — but would mail everyone an announcement of a scheduling they already received. "The meeting moved online" is a different message from "the meeting is booked", so it gets different copy, a different subject, and a body that leads with *the time has not changed*.
+
+That route re-issues the invite rather than only writing the record, because a calendar entry is exactly where the link needs to land and an email carrying an `.ics` is the only channel to it. **An unchanged value writes nothing and sends nothing** — without that guard, opening the editor and closing it again would mail the whole group.
+
+**Client:** `components/MeetingLinkField.jsx` is shared by both surfaces so validation, affordances and copy cannot drift. The Jitsi room (`https://meet.jit.si/avails-<rkey>`, deterministic from the rkey) is **offered, never pre-filled** — a room needs no account so suggesting one is nearly free, but assuming one presumes the meeting is online, and plenty of community meetings are in a room with chairs. On the finalized card, Join sits directly under the time in Confirmed Green (teal there would be a second brand voice inside a green card), with the host shown as a quiet non-underlined suffix and the full URL on the anchor. The field renders *below* the teal scheduling bar rather than inside it: white on Gather Teal measures 3.75:1, fine for that bar's large text and buttons, under AA for a field label and an error message.
+
 ## Client architecture
 
 ### Pages

--- a/server/src/middleware/validate.js
+++ b/server/src/middleware/validate.js
@@ -256,6 +256,28 @@ export function validateFinalize(req, res, next) {
   next();
 }
 
+// PUT /:did/:rkey/meeting-link. Unlike validateFinalize, meetingUrl is REQUIRED
+// here — this route exists only to change the link, so an absent field is a
+// malformed request rather than "leave it alone". An empty string still means
+// "remove the link", which is why absence and emptiness must not collapse.
+export function validateMeetingLink(req, res, next) {
+  const { meetingUrl } = req.body ?? {};
+
+  if (meetingUrl === undefined) {
+    return res.status(400).json({ error: 'meetingUrl is required (send an empty string to remove the link)' });
+  }
+
+  let normalized;
+  try {
+    normalized = normalizeMeetingUrl(meetingUrl);
+  } catch (err) {
+    return res.status(400).json({ error: err.message });
+  }
+
+  req.validatedBody = { meetingUrl: normalized };
+  next();
+}
+
 export function validateGoogleEvent(req, res, next) {
   const { googleEventId, googleCalendarId } = req.body;
 

--- a/server/src/routes/polls.js
+++ b/server/src/routes/polls.js
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { requireAuth } from '../middleware/auth.js';
-import { validatePollCreate, validatePollUpdate, validateGoogleEvent, validateFinalize } from '../middleware/validate.js';
+import { validatePollCreate, validatePollUpdate, validateGoogleEvent, validateFinalize, validateMeetingLink } from '../middleware/validate.js';
 import { indexPoll, updatePollStatus, updatePollCommunity, removePoll, listByCommunity } from '../lib/pollIndex.js';
 import { generateIcs } from '../lib/ical.js';
 import { sendEmail } from '../lib/email.js';
@@ -327,6 +327,125 @@ router.put('/:did/:rkey/finalize', requireAuth, validateFinalize, async (req, re
     }
 
     res.json({ ok: true });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// PUT /:did/:rkey/meeting-link — set, change, or remove the meeting link on a
+// poll that is ALREADY scheduled (#19).
+//
+// Deliberately not a second call to /finalize, which would work mechanically —
+// it re-sends, and the frozen UID (#167) means calendars update in place —
+// but would mail everyone an announcement of a scheduling they already
+// received. That distinction is the whole reason this route exists: "the
+// meeting moved online" is a different message from "the meeting is booked".
+//
+// Re-issuing the invite is not optional. A calendar entry is exactly where the
+// link needs to land, and an email carrying an .ics is the only channel to it;
+// a link that appears only on the poll page helps nobody who is about to join
+// from their calendar.
+router.put('/:did/:rkey/meeting-link', requireAuth, validateMeetingLink, async (req, res, next) => {
+  try {
+    const { did, rkey } = req.params;
+
+    if (req.userDid !== did) {
+      return res.status(403).json({ error: 'Only the poll creator can change the meeting link' });
+    }
+
+    const { meetingUrl } = req.validatedBody;
+
+    const pds = await resolvePds(did);
+    const getUrl = `${pds}/xrpc/com.atproto.repo.getRecord?repo=${encodeURIComponent(did)}&collection=${encodeURIComponent(POLL_COLLECTION)}&rkey=${encodeURIComponent(rkey)}`;
+    const existing = await fetch(getUrl);
+    if (!existing.ok) return res.status(404).json({ error: 'Poll not found' });
+    const existingData = await existing.json();
+
+    // An unscheduled poll has no meeting to link to and no invite to update, so
+    // the link belongs on the finalize call instead.
+    if (!existingData.value.finalTime) {
+      return res.status(400).json({
+        error: 'This poll has no scheduled time yet. Set the meeting link when you schedule it.',
+      });
+    }
+
+    // No change, no write, no mail. An accidental save must be silent: the cost
+    // of getting this wrong is everyone's inbox, every time someone opens the
+    // field and closes it again.
+    const current = existingData.value.meetingUrl || null;
+    if (current === meetingUrl) {
+      return res.json({ ok: true, changed: false, meetingUrl });
+    }
+
+    const updatedRecord = { ...existingData.value };
+    if (meetingUrl === null) delete updatedRecord.meetingUrl;
+    else updatedRecord.meetingUrl = meetingUrl;
+
+    await xrpcCall(req.oauthSession, 'com.atproto.repo.putRecord', {
+      repo: did,
+      collection: POLL_COLLECTION,
+      rkey,
+      record: updatedRecord,
+      swapRecord: existingData.cid,
+    });
+
+    const url = pollUrl(did, rkey);
+    const pollResponses = await fetchPollResponses(did, rkey);
+    const participants = pollResponses.filter((r) => r.name).map((r) => r.name);
+
+    // Same UID as the original REQUEST, so this replaces the event already in
+    // people's calendars rather than adding a second one.
+    const icsContent = generateIcs({
+      poll: updatedRecord,
+      pollUrl: url,
+      did,
+      rkey,
+      participants,
+      method: 'REQUEST',
+    });
+    const icsBase64 = Buffer.from(icsContent).toString('base64');
+
+    const emailList = [...new Set(pollResponses.filter((r) => r.email).map((r) => r.email))];
+    if (emailList.length > 0) {
+      const whenStr = new Date(updatedRecord.finalTime).toLocaleString('en-US', {
+        dateStyle: 'full',
+        timeStyle: 'short',
+        timeZone: updatedRecord.timezone || 'UTC',
+      });
+      const added = current === null;
+      const removed = meetingUrl === null;
+      const composed = composeEmail({
+        heading: removed
+          ? `${updatedRecord.title} no longer has a meeting link`
+          : added
+            ? `${updatedRecord.title} now has a meeting link`
+            : `The meeting link for ${updatedRecord.title} changed`,
+        paragraphs: [
+          // Leading with "the time has not changed" stops this reading as a
+          // reschedule, which is exactly how a second "is scheduled" email
+          // would land.
+          `The time has not changed: still ${whenStr}, for ${updatedRecord.finalDuration} minutes.`,
+          removed ? 'The video link for this meeting was removed.' : `Join here: ${meetingUrl}`,
+          'An updated calendar invite is attached. It replaces the one you already have rather than adding a second entry.',
+        ],
+        action: removed ? { label: 'View the poll', url } : { label: 'Join the call', url: meetingUrl },
+        footer: 'You are receiving this because you answered this poll. The meeting time is unchanged.',
+      });
+      await Promise.allSettled(
+        emailList.map((email) =>
+          sendEmail({
+            to: email,
+            subject: removed
+              ? `${updatedRecord.title} — meeting link removed`
+              : `${updatedRecord.title} — meeting link${added ? '' : ' updated'}`,
+            ...composed,
+            attachments: [{ filename: 'invite.ics', content: icsBase64 }],
+          })
+        )
+      );
+    }
+
+    res.json({ ok: true, changed: true, meetingUrl, notified: emailList.length });
   } catch (err) {
     next(err);
   }

--- a/server/test/meetingLink.route.test.js
+++ b/server/test/meetingLink.route.test.js
@@ -1,0 +1,268 @@
+/**
+ * PUT /api/polls/:did/:rkey/meeting-link (#19).
+ *
+ * Changing the link on an already-scheduled poll has to re-issue the calendar
+ * invite, because a calendar entry is exactly where the link needs to land and
+ * an email carrying an .ics is the only channel to it. That makes this route's
+ * side effect everyone's inbox, so the tests here are mostly about when it must
+ * NOT fire: no change, no write, no mail.
+ *
+ * Deliberately not a second call to /finalize. That would work mechanically —
+ * the frozen UID (#167) means calendars update in place — but would mail
+ * everyone an announcement of a scheduling they already received.
+ */
+
+import { describe, it, beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import cookieParser from 'cookie-parser';
+
+const POLL_COLLECTION = 'chat.avails.scheduling.poll';
+const did = 'did:plc:creator';
+const rkey = 'poll1';
+
+const mockSessions = new Map();
+mock.module('../src/lib/sessionStore.js', {
+  namedExports: {
+    sessions: mockSessions,
+    getSession: (id) => mockSessions.get(id),
+    createSession: () => 'mock-session-id',
+    deleteSession: () => {},
+    cleanupExpiredSessions: () => {},
+    getOAuthSession: () => null,
+  },
+});
+
+let sentEmails = [];
+mock.module('../src/lib/email.js', {
+  namedExports: {
+    sendEmail: async (opts) => {
+      sentEmails.push(opts);
+      return { id: 'mock-email' };
+    },
+  },
+});
+
+// The poll record the PDS will hand back, per test.
+let pollRecord;
+// Responses fetchPollResponses will see.
+let responseRecords;
+let xrpcCalls = [];
+
+const mockFetchHandler = async (pathname, opts) => {
+  xrpcCalls.push({ method: pathname.replace('/xrpc/', ''), body: JSON.parse(opts.body) });
+  return { ok: true, json: async () => ({ cid: 'cid-updated' }), text: async () => 'ok' };
+};
+
+const originalFetch = globalThis.fetch;
+globalThis.fetch = async (url, opts) => {
+  const u = String(url);
+  if (u.includes('plc.directory')) {
+    return {
+      ok: true,
+      json: async () => ({
+        service: [{ id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: 'https://mock-pds.test' }],
+      }),
+    };
+  }
+  if (u.includes('getRecord')) {
+    if (!pollRecord) return { ok: false, status: 404, json: async () => ({}) };
+    return { ok: true, json: async () => ({ value: pollRecord, cid: 'cid-existing' }) };
+  }
+  if (u.includes('listRecords')) {
+    return { ok: true, json: async () => ({ records: responseRecords }) };
+  }
+  return originalFetch(url, opts);
+};
+
+const { default: pollRoutes } = await import('../src/routes/polls.js');
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(cookieParser());
+  app.use('/api/polls', pollRoutes);
+  return app;
+}
+
+async function request(app, body, cookie = 'avails_session=creator-session') {
+  const { once } = await import('node:events');
+  const server = app.listen(0);
+  await once(server, 'listening');
+  const port = server.address().port;
+  try {
+    const res = await originalFetch(`http://localhost:${port}/api/polls/${did}/${rkey}/meeting-link`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', ...(cookie ? { Cookie: cookie } : {}) },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+    return { status: res.status, body: await res.json().catch(() => null) };
+  } finally {
+    server.close();
+  }
+}
+
+// pagedResponses keeps only records whose pollUri ends with this poll's rkey,
+// so a fixture without one is silently dropped and the route looks like it
+// mailed nobody.
+let responseSeq = 0;
+function response(name, email) {
+  responseSeq += 1;
+  return {
+    uri: `at://${did}/chat.avails.scheduling.response/r${responseSeq}`,
+    cid: `cid-r${responseSeq}`,
+    value: {
+      name,
+      ...(email ? { email } : {}),
+      pollUri: `at://${did}/${POLL_COLLECTION}/${rkey}`,
+      slots: [],
+    },
+  };
+}
+
+function scheduledPoll(extra = {}) {
+  return {
+    title: 'Weekly sync',
+    finalTime: '2026-08-11T14:00:00.000Z',
+    finalDuration: 60,
+    timezone: 'UTC',
+    status: 'finalized',
+    ...extra,
+  };
+}
+
+describe('PUT /api/polls/:did/:rkey/meeting-link', () => {
+  beforeEach(() => {
+    xrpcCalls = [];
+    sentEmails = [];
+    pollRecord = scheduledPoll();
+    responseRecords = [response('Alice', 'alice@example.test'), response('Bob', 'bob@example.test')];
+    mockSessions.set('creator-session', {
+      did,
+      handle: 'creator.test',
+      oauthSession: { fetchHandler: mockFetchHandler },
+    });
+    mockSessions.set('stranger-session', {
+      did: 'did:plc:someoneelse',
+      handle: 'nosy.test',
+      oauthSession: { fetchHandler: mockFetchHandler },
+    });
+  });
+
+  it('sets a link, writes it, and re-issues the invite to everyone who answered', async () => {
+    const res = await request(createApp(), { meetingUrl: 'https://meet.jit.si/avails-poll1' });
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.changed, true);
+    assert.equal(res.body.notified, 2);
+
+    const write = xrpcCalls.find((c) => c.method === 'com.atproto.repo.putRecord');
+    assert.ok(write, 'wrote the record');
+    assert.equal(write.body.collection, POLL_COLLECTION);
+    assert.equal(write.body.record.meetingUrl, 'https://meet.jit.si/avails-poll1');
+    // The schedule itself must survive untouched — this route changes one field.
+    assert.equal(write.body.record.finalTime, '2026-08-11T14:00:00.000Z');
+    assert.equal(write.body.swapRecord, 'cid-existing');
+
+    assert.equal(sentEmails.length, 2);
+    const ics = Buffer.from(sentEmails[0].attachments[0].content, 'base64').toString();
+    // Same UID as the original REQUEST, so calendars replace rather than add.
+    assert.match(ics, new RegExp(`UID:avails-${did}-${rkey}@`));
+    assert.match(ics, /METHOD:REQUEST/);
+    assert.match(ics, /LOCATION:https:\/\/meet\.jit\.si\/avails-poll1/);
+  });
+
+  it('says the time has not changed, so this cannot read as a reschedule', async () => {
+    await request(createApp(), { meetingUrl: 'https://meet.jit.si/avails-poll1' });
+    const mail = sentEmails[0];
+    assert.match(mail.subject, /meeting link/i);
+    assert.doesNotMatch(mail.subject, /time confirmed/i);
+    const text = JSON.stringify(mail);
+    assert.match(text, /time has not changed/i);
+  });
+
+  it('an unchanged value writes nothing and mails nobody', async () => {
+    // The failure this guards is everyone's inbox, every time someone opens the
+    // field and closes it again without editing.
+    pollRecord = scheduledPoll({ meetingUrl: 'https://meet.jit.si/avails-poll1' });
+    const res = await request(createApp(), { meetingUrl: 'https://meet.jit.si/avails-poll1' });
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.changed, false);
+    assert.deepEqual(xrpcCalls, []);
+    assert.deepEqual(sentEmails, []);
+  });
+
+  it('an empty string removes the link and says so', async () => {
+    pollRecord = scheduledPoll({ meetingUrl: 'https://meet.jit.si/avails-poll1' });
+    const res = await request(createApp(), { meetingUrl: '' });
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.changed, true);
+    assert.equal(res.body.meetingUrl, null);
+
+    const write = xrpcCalls.find((c) => c.method === 'com.atproto.repo.putRecord');
+    // Removed, not blanked: an empty string in the record would be a value every
+    // consumer then has to treat as falsy-but-present.
+    assert.ok(!('meetingUrl' in write.body.record));
+
+    assert.equal(sentEmails.length, 2);
+    assert.match(sentEmails[0].subject, /removed/i);
+    const ics = Buffer.from(sentEmails[0].attachments[0].content, 'base64').toString();
+    assert.doesNotMatch(ics, /^LOCATION:/m);
+  });
+
+  it('refuses a poll that has no scheduled time yet', async () => {
+    pollRecord = { title: 'Weekly sync', status: 'open' };
+    const res = await request(createApp(), { meetingUrl: 'https://meet.jit.si/x' });
+
+    assert.equal(res.status, 400);
+    assert.match(res.body.error, /no scheduled time/i);
+    assert.deepEqual(xrpcCalls, []);
+    assert.deepEqual(sentEmails, []);
+  });
+
+  it('refuses anyone but the creator, before reading or mailing anything', async () => {
+    const res = await request(createApp(), { meetingUrl: 'https://meet.jit.si/x' }, 'avails_session=stranger-session');
+    assert.equal(res.status, 403);
+    assert.deepEqual(xrpcCalls, []);
+    assert.deepEqual(sentEmails, []);
+  });
+
+  it('refuses an anonymous caller', async () => {
+    const res = await request(createApp(), { meetingUrl: 'https://meet.jit.si/x' }, null);
+    assert.equal(res.status, 401);
+    assert.deepEqual(sentEmails, []);
+  });
+
+  it('rejects a hostile URL before anything is written or sent', async () => {
+    for (const hostile of ['javascript:alert(1)', 'https://ok.test/a\r\nX-EVIL:1', 'not a url']) {
+      xrpcCalls = [];
+      sentEmails = [];
+      const res = await request(createApp(), { meetingUrl: hostile });
+      assert.equal(res.status, 400, hostile);
+      assert.deepEqual(xrpcCalls, []);
+      assert.deepEqual(sentEmails, []);
+    }
+  });
+
+  it('requires the field: a missing meetingUrl is malformed, not a removal', async () => {
+    // Absence must not silently mean "clear it" — that would let a buggy client
+    // wipe the link and mail everyone about it.
+    const res = await request(createApp(), {});
+    assert.equal(res.status, 400);
+    assert.match(res.body.error, /required/i);
+    assert.deepEqual(xrpcCalls, []);
+  });
+
+  it('still succeeds when nobody left an email address', async () => {
+    responseRecords = [response('Alice', null)];
+    const res = await request(createApp(), { meetingUrl: 'https://meet.jit.si/avails-poll1' });
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.changed, true);
+    assert.equal(res.body.notified, 0);
+    assert.ok(xrpcCalls.find((c) => c.method === 'com.atproto.repo.putRecord'), 'the link is still saved');
+    assert.deepEqual(sentEmails, []);
+  });
+});


### PR DESCRIPTION
Closes #19. The server half (#172) stored and delivered `meetingUrl`, but nothing in the UI could read or write it, so in practice it was MCP-only. Built from the confirmed brief in [`docs/plans/2026-08-06-meeting-links-client-brief.md`](https://github.com/Citizen-Infra/avails/blob/main/docs/plans/2026-08-06-meeting-links-client-brief.md).

## Two places set it, and they are different routes on purpose

**At schedule time** the link rides along on `PUT /finalize`, so the first invite already carries it and the common case sends one email.

**Afterwards** it goes through a new `PUT /:did/:rkey/meeting-link`. Reusing finalize would work mechanically — it re-sends, and the frozen UID (#167) means calendars update in place — but would mail everyone an announcement of a scheduling they already received. "The meeting moved online" is a different message from "the meeting is booked", so it gets its own copy, its own subject, and a body that leads with **the time has not changed**.

That route re-issues the invite rather than only writing the record, because a calendar entry is where the link needs to land and an `.ics` by email is the only channel to it.

**An unchanged value writes nothing and sends nothing.** Without that guard, opening the editor and closing it again mails the whole group. It has a test.

## The Jitsi room is offered, never pre-filled

A room needs no account, so suggesting one is nearly free. Assuming one presumes the meeting is online, and plenty of community meetings are in a room with chairs. Avails finds times; it does not decide how a group meets.

## Two things that came from looking rather than assuming

I built a static harness against the real compiled CSS, because the finalized card sits behind auth plus a scheduled poll and no ordinary screenshot reaches it. The first pass showed two defects I would not have caught by reading the diff:

- **The host suffix inherited the anchor's underline**, so `Join the call | meet.jit.si | Edit` read as three competing links.
- **Join was `text-base`** — body weight — for the one line the brief calls the responder's whole job.

Now `text-lg` semibold with a 2px underline, and the host as a quiet non-underlined suffix.

Covered at 1100px and at a pinned 390px column: no link, link set, a long Zoom URL, the inline editor with a server error, and the empty field with the Jitsi offer. **The 390px column is deliberate** — headless `--window-size` width is not the layout viewport, so shooting at 390 crops the page instead of reflowing it, which is exactly the trap that made my first mobile pass unreadable.

## Placement decisions

**The field renders below the teal scheduling bar, not inside it.** White on Gather Teal measures **3.75:1** — fine for that bar's large text and buttons, under AA for a field label and an error message. On Paper Cream both clear comfortably. The bar is also already a dense control strip that would crowd at `sm`.

**Join sits directly under the time in Confirmed Green (`#15803d`)**, not Gather Teal: teal inside a green card would put two brand voices in one component. The existing OpenMeet link in that card already uses the same green.

**Inline, never a modal.** One field does not earn a dialog.

`MeetingLinkField` is shared by both surfaces so validation, affordances, and copy cannot drift apart.

## Tests

10 new route tests; full suite **284 pass**. Client build passes. Impeccable detector clean on all three changed UI files.

The route tests are mostly about when the side effect must *not* fire, since that side effect is everyone's inbox: unchanged value, unscheduled poll, non-creator, anonymous, hostile URL, missing field. Plus the positive paths — sets and mails with the same UID, removes and says so, and still saves when nobody left an email address.

One fixture bug worth noting because it looked like a route bug: `pagedResponses` keeps only records whose `pollUri` ends with the poll's rkey, so my first fixtures were silently dropped and the route appeared to mail nobody.